### PR TITLE
Replace underscores in secret names with hyphens

### DIFF
--- a/docs/reference/secrets.md
+++ b/docs/reference/secrets.md
@@ -21,10 +21,10 @@ In Kubernetes we can leverage the [secrets api](https://kubernetes.io/docs/conce
 From the commandline use
 
 ```sh
-kubectl create secret generic secret_api_key --from-file=secret_api_key=~/secrets/secret_api_key.txt
+kubectl create secret generic secret-api-key --from-file=secret-api-key=~/secrets/secret_api_key.txt
 ```
 
-Here we have explicitly named the key of the secret value so that when it is mounted into the function container, it will be named exactly `secret_api_key` instead of `secret_api_key.txt`.
+Here we have explicitly named the key of the secret value so that when it is mounted into the function container, it will be named exactly `secret-api-key` instead of `secret_api_key.txt`.
 
 ### Define a secret in Docker Swarm
 
@@ -33,7 +33,7 @@ For sensitive value we can leverage the [Docker Swarm Secrets](https://docs.dock
 From the command line use
 
 ```sh
-docker secret create secret_api_key ~/secrets/secret_api_key.txt
+docker secret create secret-api-key ~/secrets/secret_api_key.txt
 ```
 
 ## Use the secret in your function
@@ -51,7 +51,7 @@ Now, update your stack file to include the secret:
       skip_build: true
       image: functions/api-key-protected:latest
       secrets:
-      - secret_api_key
+      - secret-api-key
 ```
 
 and then deploy `faas-cli deploy -f ./stack.yaml`


### PR DESCRIPTION
Kubernetes has a naming constaint which means that the patterm must fit
'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'. This
change replaces the underscores in the secret names so the examples are
functional on both Docker and Kubernetes.

Fixes #10 

Signed-off-by: rgee0 <richard@technologee.co.uk>