### PR TITLE
Fix broken documentation formatting

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -4,7 +4,7 @@ This guide is for deployment to a vanilla Kubernetes 1.8 or 1.9 cluster running 
 
 ## Kubernetes
 
-OpenFaaS is Kubernetes-native and uses *Deployments*, *Service*s and *Secret*s. For more detail check out the ["faas-netes" repository](https://github.com/openfaas/faas-netes).
+OpenFaaS is Kubernetes-native and uses *Deployments*, *Services* and *Secrets*. For more detail check out the ["faas-netes" repository](https://github.com/openfaas/faas-netes).
 
 !!! note
     For deploying on a cloud that supports Kubernetes *LoadBalancers* you may also want to apply the configuration in: `cloud/lb.yml`.


### PR DESCRIPTION
On the documentation website

```
*foo*s is rendered as *foo*s rather than an italic foo followed by an s.
```

For reference, see the attached screenshot.

![screenshot 2018-04-19 at 7 45 37 pm](https://user-images.githubusercontent.com/486199/39023711-56258e0e-440a-11e8-8827-90e9ba76fcbb.png)
