### PR TITLE
Keep docs in sync with TestDrive.md

### DIFF
--- a/docs/deployment/docker-swarm.md
+++ b/docs/deployment/docker-swarm.md
@@ -36,10 +36,14 @@ $ git clone https://github.com/openfaas/faas && \
   ./deploy_stack.sh
 ```
 
-`./deploy_stack.sh` can be run at any time and includes a set of sample functions. You can read more about these in the [TestDrive document](https://github.com/openfaas/faas/blob/master/TestDrive.md)
-
 !!! note
     If you want to try newer features you can checkout the `master` branch, but we do not recommend that for first-time users.
+
+To deploy a set of sample functions, [install the OpenFaaS CLI](cli/install/) then deploy the functions in `stack.yml` by running:
+
+```
+faas deploy
+```
 
 ## 2.1 Test out the UI
 


### PR DESCRIPTION
Related work: faas repo PR #700 - Remove sample functions for swarm

This is a change to the deployment guide to reflect the change made by [PR 700](https://github.com/openfaas/faas/pull/700) in the [faas](https://github.com/openfaas/faas) repo. Provides instructions on how to deploy the sample functions after the initial stack is deployed.