### PR TITLE
Get checkboxes working docs

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -145,6 +145,7 @@ You can then find the logs of the function using Docker Swarm or Kubernetes as l
 Most problems reported via GitHub or Slack stem from a configuration problem or issue with a function. Here is a checklist of things you can try before digging deeper:
 
 Checklist:
+
 * [ ] All core services are deployed: i.e. gateway
 * [ ] Check functions are deployed and started
 * [ ] Check request isn't timing out at the gateway or the function level


### PR DESCRIPTION
This change is needed to get checkboxes working in the docs page. Checkboxes are currently broken in this page:

https://docs.openfaas.com/deployment/troubleshooting/#healthcheck

The fix is to add CSS for checkboxes, and add spacing.

Tested by running:

```
docker run --rm -it -p 8000:8000 -v `pwd`:/docs squidfunk/mkdocs-material
```