### PR TITLE
Redirect Derek file to openfaas/faas file

### DIFF
--- a/.DEREK.yml
+++ b/.DEREK.yml
@@ -1,12 +1,1 @@
-maintainers:
- - alexellis
- - rgee0
- - ericstoekl
- - kenfdev
- - BurtonR
- - iyovcheva
- - stefanprodan
-
-features:
- - dco_check
- - comments
+ redirect: https://raw.githubusercontent.com/openfaas/faas/master/.DEREK.yml 


### PR DESCRIPTION
This change redirects the derek file to the main openfaas/faas
repo to allow us to maintain a single source of authorized derek
users at the main repository.

The OpenFaas organization uses several repositories for the code
base that are all related. Consolidating the derek file will make
it easier to maintain when adding or removing users

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

This comes from the faas repo issue: https://github.com/openfaas/faas/issues/630