### PR TITLE
Style header and footer-nav to match landing page

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -7,3 +7,7 @@
     width: 36px;
     height: 36px;
 }
+
+.md-header,.md-footer-nav {
+    background-image: linear-gradient(45deg, rgb(53, 112, 227) 0%, rgb(53, 112, 227) 24%, rgb(42, 125, 227) 53%, rgb(27, 141, 226) 78%, rgb(8, 162, 225) 100%);
+}


### PR DESCRIPTION
This commit updates the styling of the docs `header` and `footer-nav` elements to match the linear gradient styling on the main https://www.openfaas.com website.

It leaves the footer-meta as-is for contrast.

**new**
<img width="1226" alt="screen shot 2018-06-26 at 23 54 02" src="https://user-images.githubusercontent.com/83862/41943684-4c6801e0-799c-11e8-9b13-1ca9ed8606c1.png">

**old**
<img width="1225" alt="screen shot 2018-06-26 at 23 51 54" src="https://user-images.githubusercontent.com/83862/41943621-0825672a-799c-11e8-8be8-ec843b3af8d1.png">

**new**
<img width="1227" alt="screen shot 2018-06-26 at 23 54 12" src="https://user-images.githubusercontent.com/83862/41943695-526b0b46-799c-11e8-9228-fd94e67dd340.png">

**old**
<img width="1226" alt="screen shot 2018-06-26 at 23 52 04" src="https://user-images.githubusercontent.com/83862/41943633-0efb7c88-799c-11e8-8a4e-a4794d304c2e.png">

**main site**
<img width="1255" alt="screen shot 2018-06-26 at 23 54 29" src="https://user-images.githubusercontent.com/83862/41943710-5bdbee70-799c-11e8-9b6b-a4728e0da7df.png">
