### PR TITLE
Fix link to /cli/install in swarm deploy guide

### DIFF
--- a/docs/deployment/docker-swarm.md
+++ b/docs/deployment/docker-swarm.md
@@ -49,7 +49,7 @@ Within a few seconds (or minutes if on a poor WiFi connection) the API gateway a
 
 ## 2.2 Deploy the sample functions
 
-The earlier `git clone` included a set of sample functions in `stack.yml`, to deploy them [install the OpenFaaS CLI](cli/install/) and run:
+The earlier `git clone` included a set of sample functions in `stack.yml`, to deploy them [install the OpenFaaS CLI](/cli/install/) and run:
 
 ```
 faas deploy


### PR DESCRIPTION
The link to /cli/install on line 52 was 'cli/install' (missing the / prefix) which
caused the live link to hit a 404.  This adds / to the front.

Signed-off-by: rgee0 <richard@technologee.co.uk>