### PR TITLE
Add auth instructions for Swarm

### DIFF
--- a/docs/deployment/docker-swarm.md
+++ b/docs/deployment/docker-swarm.md
@@ -36,7 +36,7 @@ $ git clone https://github.com/openfaas/faas && \
 ```
 
 !!! info
-    Basic authentication is now enabled by default for your protection. If you need to disable it pass the flag --no-auth to the ./deploy_stack.sh command above.
+    As of OpenFaaS 0.8.6 basic authentication will be enabled by default when running ./deploy\_stack.sh. If you need to disable it pass the flag `--no-auth` to the ./deploy_stack.sh script as above.
 
 ### 2.1 Store your admin credentials
 
@@ -52,9 +52,9 @@ Attempting to create credentials for gateway..
 password-stdin
 ```
 
-Run the command as you see it in your console, do not copy/paste the login command.
+Run the command as you see it in your console, do not copy/paste the login command. Once you run `faas-cli login` your password will be stored as a hash at `~/.openfaas/config.yaml`.
 
-You will need the password for using the UI and REST API on the gateway, but you can invoke your functions without it.
+You will need the password for the CLI, UI and REST API on the gateway, but you can invoke your functions without it.
 
 ## 2.1 Test out the UI
 

--- a/docs/deployment/docker-swarm.md
+++ b/docs/deployment/docker-swarm.md
@@ -35,8 +35,26 @@ $ git clone https://github.com/openfaas/faas && \
   ./deploy_stack.sh
 ```
 
-!!! note
-    If you want to try newer features you can checkout the `master` branch, but we do not recommend that for first-time users.
+!!! info
+    Basic authentication is now enabled by default for your protection. If you need to disable it pass the flag --no-auth to the ./deploy_stack.sh command above.
+
+### 2.1 Store your admin credentials
+
+The default configuration will create a username and password combination for you:
+
+```
+Attempting to create credentials for gateway..
+...
+[Credentials]
+ username: admin
+ password: <some_hash_secret>
+ echo -n <some_hash_secret> | faas-cli login --username=admin --
+password-stdin
+```
+
+Run the command as you see it in your console, do not copy/paste the login command.
+
+You will need the password for using the UI and REST API on the gateway, but you can invoke your functions without it.
 
 ## 2.1 Test out the UI
 
@@ -52,7 +70,8 @@ Within a few seconds (or minutes if on a poor WiFi connection) the API gateway a
 The earlier `git clone` included a set of sample functions in `stack.yml`, to deploy them [install the OpenFaaS CLI](/cli/install/) and run:
 
 ```
-faas deploy
+$ faas deploy -f \
+  https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
 ```
 
 ## 3.0 Start the hands-on labs

--- a/docs/deployment/play-with-docker.md
+++ b/docs/deployment/play-with-docker.md
@@ -46,6 +46,9 @@ git clone https://github.com/openfaas/faas && \
   ./deploy_stack.sh
 ```
 
+!!! info
+    Basic authentication is now enabled by default for your protection so note down your credentials. If you need to disable it pass the flag --no-auth to the ./deploy_stack.sh command above.
+
 `./deploy_stack.sh` can be run at any time and deploys the core OpenFaas components. You can read more about these in the [TestDrive document](https://github.com/openfaas/faas/blob/master/TestDrive.md)
 
 ## 2.1 Test out the UI

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -198,6 +198,16 @@ $ docker service ls -q | xargs docker service rm
 
 *Use with caution*
 
+#### I forgot my gateway password
+
+```
+$ docker service rm print-password \
+ ; docker service create --detach --secret basic-auth-password --restart-condition=none --name=print-password alpine:3.7 cat /run/secrets/basic-auth-password
+
+$ docker service logs print-password
+21f596c9cd75a0fe5e335fb743995d18399e83418a37a79e719576a724efbbb6
+```
+
 ### Kubernetes
 
 If you have deployed OpenFaaS to the recommended namespaces then functions are in the `openfaas-fn` namespace and the core services are in the `openfaas` namespace. The `-n` flag to `kubectl` sets the namespace to look at.
@@ -266,6 +276,21 @@ From within the `faas-netes` folder:
 
 ```
 $ kubectl delete -f namespaces.yml,./yaml/
+```
+
+#### I forgot my gateway password
+
+Use the following:
+
+```
+kubectl get -n openfaas secret -o yaml
+```
+
+Then copy/paste the value as below:
+
+```
+$ echo -n "YWRtaW4xMjM0Cg==" | base64 --decode
+admin1234
 ```
 
 ## Watchdog


### PR DESCRIPTION
Updates Swarm deployment guide and play-with-docker instrucctions
to advise user to keep credentials and at the least to log in via
the faas-cli.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>