### PR TITLE
Docs for write_debug option for queue worker

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -20,6 +20,11 @@ You can tune the values for the number of tasks each queue worker may run in par
 
 The [OpenFaaS workshop](https://github.com/openfaas/workshop) has more instructions on running tasks asynchronously.
 
+
+* Verbose Output
+
+The Queue Worker component enables asynchronous processing of function requests. The default verbosity level hides the message content, but this can be viewed by setting write_debug to true when deploying.
+
 ## Timeouts
 
 Default timeouts are configured at the HTTP level and must be set both on the gateway and the function.


### PR DESCRIPTION
Signed-off-by: Eric Stoekl <ems5311@gmail.com>

This change adds documentation concerning the `write_debug` option on the queue worker.

It is under the Asynchronous Function info section in `troubleshooting.md`

Looks like this in the documentation page:

https://imgur.com/5e9666f4-eded-443f-984d-32189a7a2ee2

This is related to this PR in the nats-queue-worker repo: https://github.com/openfaas/nats-queue-worker/pull/29