### PR TITLE
Center align the logos

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -12,6 +12,10 @@
     background-image: linear-gradient(45deg, rgb(53, 112, 227) 0%, rgb(53, 112, 227) 24%, rgb(42, 125, 227) 53%, rgb(27, 141, 226) 78%, rgb(8, 162, 225) 100%);
 }
 
+.logos {
+    text-align: center;
+}
+
 .logos img {
     flex: 1 1 auto;
     padding: 22px;


### PR DESCRIPTION
This fix centers the logos so that they look better on mobile devices.
Closes #60

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

## **Before**

Wide Screen
<img width="1249" alt="ss 2018-08-27 23 10 42" src="https://user-images.githubusercontent.com/3941889/44664923-a0b2a280-aa4f-11e8-9ba7-28fea31fd436.png">

Mobile Screen
<img width="184" alt="ss 2018-08-27 23 11 12" src="https://user-images.githubusercontent.com/3941889/44664946-ae682800-aa4f-11e8-9c16-d86b50e1db4a.png">

## **After**

Wide Screen
<img width="1259" alt="ss 2018-08-27 23 12 47" src="https://user-images.githubusercontent.com/3941889/44664962-b88a2680-aa4f-11e8-830e-92181ee72f4e.png">

Mobile Screen
<img width="184" alt="ss 2018-08-27 23 12 34" src="https://user-images.githubusercontent.com/3941889/44664972-bfb13480-aa4f-11e8-9a4f-8ef8b967f09c.png">
