### PR TITLE
Add template pull instruction

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,7 +125,11 @@ There are currently no sample functions built into this stack, but we can deploy
       name: faas
       gateway: http://192.168.4.95:31112
     ```
+    Before deploying the gateway changes make sure you pull the [templates from GitHub:](https://github.com/openfaas/templates)
 
+    ```bash
+    $ faas-cli template pull
+    ```
     Now deploy the samples:
 
     ```bash


### PR DESCRIPTION
Signed-off-by: Vivek Sridhar <vsridhar@digitalocean.com>

Before running faas-cli deploy, the user must have a templates folder which isn't present so the user got an error. 

$ faas-cli deploy -f stack.yml
Deploying: nodejs-echo.
Template directory may be missing or invalid, please run "faas template pull"
Error: stat ./template/node/template.yml: no such file or directory

This adds the instruction to pull the templates from GitHub to Kubernetes doc.

```
$ faas-cli template pull
```
Will be adding similar information for Docker Swarm Deployment.