### PR TITLE
Add template store to docs and some const explanation

### DIFF
--- a/docs/cli/templates.md
+++ b/docs/cli/templates.md
@@ -324,6 +324,54 @@ You can use your own Git repository for a custom or forked set of templates. Thi
 
 See `faas-cli template pull` for more information.
 
+If you want to set up your own default template location, specify the `OPENFAAS_TEMPLATE_URL` environmental variable the following way:
+
+```bash
+export OPENFAAS_TEMPLATE_URL=https://raw.githubusercontent.com/user/mytemplate/customtemplates
+```
+
+#### 8.4 Download templates from the template store
+
+> Note: In order to access the template store you need `0.8.1` version of the CLI or higher
+
+Check what templates are available in the template store with the CLI by typing:
+
+```bash
+faas-cli template store list
+```
+
+Pull the desired template by specifying `NAME` attribute only:
+
+```bash
+faas-cli template store pull go
+```
+
+or pull the template by mixing the `REPOSITORY` and `NAME` attributes the following way:
+
+```bash
+faas-cli template store pull openfaas/go
+```
+
+To get more information on specific store use the `describe` verb like:
+
+```bash
+faas-cli template store describe openfaas/go
+```
+
+or if there is no collision between names use only the name field:
+
+```bash
+faas-cli template store describe go
+```
+
+If you have your own store with templates, you can set that as your default official store by setting the environmental variable `OPENFAAS_TEMPLATE_STORE_URL` the following way:
+
+```bash
+export OPENFAAS_TEMPLATE_STORE_URL=https://raw.githubusercontent.com/user/openfaas-templates/templates.json
+```
+
+Now the source of the store is changed to the URL you have specified above.
+
 ## ARM / Raspberry Pi
 
 Templates for ARM and Raspberry Pi are provided on a best-effort basis. If you can help with maintenance please let the project contributors know.

--- a/docs/contributing/get-started.md
+++ b/docs/contributing/get-started.md
@@ -69,6 +69,13 @@ The incubator organisation is for experiments, research and for getting quick fe
 | [of-watchdog](https://github.com/openfaas-incubator/of-watchdog)              | The OpenFaaS watchdog re-written with mode-abstractions for both STDIO & HTTP |
 | [faas-idler](https://github.com/openfaas-incubator/faas-idler)         | Scale OpenFaaS functions to zero replicas after specified period of inactivity   |
 | [openfaas-operator](https://github.com/openfaas-incubator/openfaas-operator)         | The OpenFaaS CRD Operator for Kubernetes   |
+| [kafka-connector](https://github.com/openfaas-incubator/kafka-connector)         | The Kafka connector connects OpenFaaS functions to Kafka topics   | 
+| [node10-express-template](https://github.com/openfaas-incubator/node10-express-template) | Node.js 10 Express template providing additional context and control over the HTTP response from your function |
+| [golang-http-template](https://github.com/openfaas-incubator/golang-http-template) | Golang template providing additional control over the HTTP request and response.|
+| [powershell-http](https://github.com/openfaas-incubator/powershell-http-template) | PowerShell HTTP template |
+| [ruby-http](https://github.com/openfaas-incubator/ruby-http) | A Ruby HTTP template for OpenFaaS |
+| [python-flask-template](https://github.com/openfaas-incubator/python-flask-template) | OpenFaaS templates for Python 2.7/3.6 with Flask |
+| [node8-express-template](https://github.com/openfaas-incubator/node8-express-template) | Node.js 8 template for OpenFaaS with HTTP via Express.js |
 
 
 https://github.com/openfaas-incubator/


### PR DESCRIPTION
Closes #92

This closes the Issue I have opened adds detail around

`OPENFAAS_TEMPLATE_STORE_URL` and `OPENFAAS_TEMPLATE_URL` constants along with adding documentation on the new faas-cli feature `template store`