### PR TITLE
Document build_options, readonly_root_filesystem, skip_build

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -65,16 +65,16 @@ This an optional boolean field, set to `false` by default.
 
 #### Function: Build Options
 
-The `build_options` allows you to pass a list of [Docker build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to the build process.  When the language template supports it, this allows you to customize the build without modifying the underlying template.
+The `build_options` field can be used to you to pass a list of [Docker build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to the build process.  When the language template supports it, this allows you to customize the build without modifying the underlying template.
 
-For example, the [official python3 language template](https://github.com/openfaas/templates/blob/master/template/python3/Dockerfile) allows passing additional Alpine `apk` packages to be installed during build process. To isntall the [`ca-certificates`](https://pkgs.alpinelinux.org/package/edge/main/x86_64/ca-certificates) package for your `python3` function, you can specify
+For example, the [official python3 language template](https://github.com/openfaas/templates/blob/master/template/python3/Dockerfile) allows passing additional Alpine `apk` packages to be installed during build process. To install the [`ca-certificates`](https://pkgs.alpinelinux.org/package/edge/main/x86_64/ca-certificates) package for your `python3` function, you can specify
 
 ```yaml
 build_options:
 - ca-certificates
 ```
 
-Important note: that the configuration of this value is dependent on the language template.
+Important note: that the configuration of this value is dependent on the language template.  The template author must specify one or more [`ARG`](https://docs.docker.com/engine/reference/builder/#arg) in the `Dockerfile`.
 
 #### Function: Environmental variables
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -57,6 +57,25 @@ The function `handler` field refers to a folder where the function's source code
 
 The `image` field refers to a Docker image reference, this could be on the Docker Hub, in your local Docker library or on another remote server.
 
+#### Function: Skip build
+
+The `skip_build` field controls if the CLI will attempt to build the Docker image for the function.  When `true`, the build step is skipped and you should see a message printed to the terminal `Skipping build of: "function name"`.
+
+This value is set as a boolean.
+
+#### Function: Build Options
+
+The `build_options` allows you to pass a list of [Docker build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to the build process.  When the language template supports it, this allows you to customize the build without modifying the underlying template.
+
+For example, the [official python3 language template](https://github.com/openfaas/templates/blob/master/template/python3/Dockerfile) allows passing additional Alpine `apk` packages to be installed during build process. To isntall the [`ca-certificates`](https://pkgs.alpinelinux.org/package/edge/main/x86_64/ca-certificates) package for your `python3` function, you can specify
+
+```yaml
+build_options:
+- ca-certificates
+```
+
+Important note: that the configuration of this value is dependent on the language template.
+
 #### Function: Environmental variables
 
 You can set configuration via environmental variables either in-line within the YAML file or in a separate external file. Do not store confidential or private data in environmental variables. See: secrets.
@@ -108,6 +127,14 @@ secrets:
   - s3_secret_key
 ```
 
+#### Function: Read-Only Root Filesystem
+
+The `readonly_root_filesystem` indicates that the function file system will be set to read-only except for a scratch/temporary folder `/tmp`.  This prevents the function from writing to or modifying the filesystem (e.g. system files). This is used to provide stricter security for your functions. You can set this value as a boolean:
+
+```yaml
+readonly_root_filesystem: true
+```
+
 #### Function: Constraints
 
 Constraints are passed directly to the underlying container orchestrator. They allow you to pin a function to certain host or type of host.
@@ -128,7 +155,7 @@ Or only using nodes running with Windows:
 
 #### Function: Labels
 
-Labels can be applied through a map which is passed directly to the container scheduler. 
+Labels can be applied through a map which is passed directly to the container scheduler.
 Labels are also available from the OpenFaaS REST API for querying or grouping functions.
 
 Example of using a label to group by user or apply a `canary` label:
@@ -139,10 +166,10 @@ Example of using a label to group by user or apply a `canary` label:
      Git-Owner: alexellis
 ```
 
-> Important note: When used with a Kubernetes provider, labels support a restricted character set and length. 
-*"Valid label values must be 63 characters or less and must be empty or begin and end with an alphanumeric character 
+> Important note: When used with a Kubernetes provider, labels support a restricted character set and length.
+*"Valid label values must be 63 characters or less and must be empty or begin and end with an alphanumeric character
 ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between."*
-> 
+>
 >See [Syntax and character set](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
 for more information
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -59,9 +59,9 @@ The `image` field refers to a Docker image reference, this could be on the Docke
 
 #### Function: Skip build
 
-The `skip_build` field controls if the CLI will attempt to build the Docker image for the function.  When `true`, the build step is skipped and you should see a message printed to the terminal `Skipping build of: "function name"`.
+The `skip_build` field controls whether the CLI will attempt to build the Docker image for the function.  When `true`, the build step is skipped and you should see a message printed to the terminal `Skipping build of: "function name"`.
 
-This value is set as a boolean.
+This an optional boolean field, set to `false` by default.
 
 #### Function: Build Options
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -67,7 +67,7 @@ This an optional boolean field, set to `false` by default.
 
 The `build_options` field can be used to you to pass a list of [Docker build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to the build process.  When the language template supports it, this allows you to customize the build without modifying the underlying template.
 
-For example, the [official python3 language template](https://github.com/openfaas/templates/blob/master/template/python3/Dockerfile) allows passing additional Alpine `apk` packages to be installed during build process. To install the [`ca-certificates`](https://pkgs.alpinelinux.org/package/edge/main/x86_64/ca-certificates) package for your `python3` function, you can specify
+For example, the [official python3 language template](https://github.com/openfaas/templates/blob/master/template/python3/Dockerfile) can be used to additional Alpine `apk` packages to be installed during build process. To install the [`ca-certificates`](https://pkgs.alpinelinux.org/package/edge/main/x86_64/ca-certificates) package for your `python3` function, you can specify
 
 ```yaml
 build_options:
@@ -129,11 +129,13 @@ secrets:
 
 #### Function: Read-Only Root Filesystem
 
-The `readonly_root_filesystem` indicates that the function file system will be set to read-only except for a scratch/temporary folder `/tmp`.  This prevents the function from writing to or modifying the filesystem (e.g. system files). This is used to provide stricter security for your functions. You can set this value as a boolean:
+The `readonly_root_filesystem` indicates that the function file system will be set to read-only except for the temporary folder `/tmp`.  This prevents the function from writing to or modifying the filesystem (e.g. system files). This is used to provide tighter security for your functions. You can set this value as a boolean:
 
 ```yaml
 readonly_root_filesystem: true
 ```
+
+This an optional boolean field, set to `false` by default.
 
 #### Function: Constraints
 


### PR DESCRIPTION
**What**
- Update the yaml reference with documentation for build_options,
readonly_root_filesystem, skip_build
- Trims some trailing whitespace (my editor did this automatically)

Resolves #80
