### PR TITLE
Fix syntax error removing namespaces

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -259,7 +259,7 @@ helm delete --purge openfaas
 If installed via YAML files:
 
 ```
-kubectl delete namespace openfaas,openfaas-fn
+kubectl delete namespace openfaas openfaas-fn
 ```
 
 ## Troubleshooting Swarm or Kubernetes


### PR DESCRIPTION
## Tested
On kubernetes version

```
kubectl version
Client Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.1", GitCommit:"eec55b9ba98609a46fee712359c7b5b365bdd920", GitTreeState:"clean", BuildDate:"2018-12-13T10:39:04Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.1", GitCommit:"eec55b9ba98609a46fee712359c7b5b365bdd920", GitTreeState:"clean", BuildDate:"2018-12-13T10:31:33Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
```

Error with current docs

```
kubectl delete namespace openfaas,openfaas-fn
Error from server (NotFound): namespaces "openfaas,openfaas-fn" not found
```

Fix
```
kubectl delete namespace openfaas openfaas-fn
namespace "openfaas" deleted
namespace "openfaas-fn" deleted
```