### PR TITLE
Use local namespaces.yml during k8s deployment

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -78,14 +78,14 @@ This step assumes you are running `kubectl` on a master host.
     * openfaas-fn - for functions
 
     ```bash
-    $ kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+    $ cd faas-netes && \
+    kubectl apply -f ./namespaces.yml
     ```
 
     Now deploy OpenFaaS:
 
     ```bash
-    $ cd faas-netes && \
-    kubectl apply -f ./yaml
+    $ kubectl apply -f ./yaml
     ```
 
     !!! note


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This updates the Kubernetes `kubectl` deployment steps, to use the local `namespaces.yml` from the cloned `faas-netes` repo rather than pulling from GitHub.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change (n/a)

Since we clone `faas-netes` and use it for all other `yml` it makes more sense to use the local `namespaces.yml`.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed using these steps on local k8s, also visual inspection of docs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
