### PR TITLE
Add notes about GKE load-balancer default timeouts

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -25,6 +25,8 @@ A guide is available for configuring minikube here:
       --user="$(gcloud config get-value core/account)"
     ```
 
+    Also, ensure any [default load-balancer timeouts within GKE](https://cloud.google.com/load-balancing/docs/https/#timeouts_and_retries) are understood and configured appropriately.
+
 ### Install the `faas-cli`
 
 You can install the OpenFaaS CLI using `brew` or a `curl` script.

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -154,6 +154,10 @@ For asynchronous invocations of functions a separate timeout can be configured a
 
 If the `ack_wait` is exceeded the task will not be acknowledge and the queue system will retry the invocation.
 
+### Timeouts - Cloud Service Providers
+
+There are situations where timeout values external to OpenFaaS may impact successful function execution.  A typical scenario is where a cloud platform's load balancer product is fronting the cluster in which OpenFaaS is running.  A common example is when using the [GCP Kubernetes product, GKE](https://cloud.google.com/load-balancing/docs/https/#timeouts_and_retries). 
+
 ## Function execution logs
 
 By default the functions will not log out the result, but just show how long the process took to run and the length of the result in bytes.


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
At the time of writing the default load-balancer timeout within GKE is 30 seconds.  This change adds notes within the Kubernetes deployment guide and the troubleshooting section to highlight that there may be timeout configuration outside of OpenFaaS while also drawing attention specifically to GKE.

## Motivation and Context
See https://github.com/openfaas/faas/issues/1016

## How Has This Been Tested?
Docs change.  Peer review to ensue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
