### PR TITLE
Edit Reference guide with `faas-cli secret`

### DIFF
--- a/docs/reference/secrets.md
+++ b/docs/reference/secrets.md
@@ -8,8 +8,8 @@ Using secrets is a two step process. First you need to define a new secret in yo
 
 * Secrets can be specified via API, CLI or YAML file
 * You can use one to many secrets in a function
-* Secrets must exist in the cluster at deployment time
-* Secrets need to be created with `kubectl` or `docker secret create`, but [in the near future](https://github.com/openfaas/faas/issues/807) an API will exist to create, list, delete and update secrets.
+* Specified secrets must exist in the cluster at function deploy. A function may consume zero to many secrets
+* Secrets can be created with `faas-cli secret create`
 
 ### A note on environmental variables
 
@@ -31,44 +31,9 @@ R^YqzKzSJw51K9zPpQ3R3N
 
 Now we can import the secret into the cluster.
 
-#### Define a secret in Kubernetes
+### Define a secret
 
-In Kubernetes we can leverage the [built-in secret store](https://kubernetes.io/docs/concepts/configuration/secret/) to securely store secrets for functions.
-
-Type in:
-
-```sh
-kubectl create secret generic secret-api-key \
-  --from-file=secret-api-key=secret-api-key.txt \
-  --namespace openfaas-fn
-```
-
-Here we have explicitly named the key of the secret value so that when it is mounted into the function container, it will be named exactly `secret-api-key` instead of `secret_api_key.txt`.
-
-You can skip creating a file and use input directly from the command-line like this:
-
-```sh
-kubectl create secret generic secret-api-key \
-  --from-literal secret-api-key="R^YqzKzSJw51K9zPpQ3R3N" \
-  --namespace openfaas-fn
-```
-
-#### Define a secret in Docker Swarm
-
-Docker has a built-in [secrets store](https://docs.docker.com/engine/swarm/secrets/) just like Kubernetes which can be used to securely store secrets for our functions.
-
-Type in:
-
-```sh
-docker secret create secret-api-key \
- ~/secrets/secret_api_key.txt
-```
-
-or:
-
-```sh
-echo "R^YqzKzSJw51K9zPpQ3R3N" | docker secret create secret-api-key -
-```
+For more details on how to define a secret, please see the [Manage secrets](https://docs.openfaas.com/cli/secrets/) section of the CLI
 
 ### Use the secret in your function
 


### PR DESCRIPTION
Edit secrets section within the Reference guide to document usage
of the nesw Secrets API and CLI command

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Raised on slack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running docs locally:

<img width="845" alt="screen shot 2019-01-25 at 16 13 32" src="https://user-images.githubusercontent.com/4160133/51751165-d9b57880-20bc-11e9-8aaa-996da37f7383.png">

and 
<img width="703" alt="screen shot 2019-01-25 at 16 14 27" src="https://user-images.githubusercontent.com/4160133/51751177-dde19600-20bc-11e9-8b75-d517d6c80b94.png">


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
