### PR TITLE
correcting order in secret create command example

### DIFF
--- a/docs/reference/secrets.md
+++ b/docs/reference/secrets.md
@@ -34,9 +34,10 @@ Now we can import the secret into the cluster.
 #### Define the secret with `faas-cli`
 
 ```sh
-faas-cli create secret secret-api-key \
+faas-cli secret create secret-api-key \
   --from-file=secret-api-key.txt
 ```
+
 You can create the secret with `faas-cli secret create`, or by using the Docker / Kubernetes CLI.
 
 #### Define a secret in Kubernetes (advanced)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pretty sure the `secret create` example has the wrong order on the arguments,

```shell
$ faas-cli create secret secret-api-key
Unknown command "create" for "faas-cli"
```
While chaning the order:

```shell
$ faas-cli secret create secret-api-key
Reading from STDIN - hit (Control + D) to stop.
```

## Motivation and Context
Non-working example

## How Has This Been Tested?
See description ☝️ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
