### PR TITLE
Add custom health check annotations docs

### DIFF
--- a/docs/reference/workloads.md
+++ b/docs/reference/workloads.md
@@ -22,7 +22,7 @@ On Kubernetes:
 * or enable httpProbe in the `helm` chart and implement `/_/health` as a HTTP endpoint
 * create a lock file in `/tmp/.lock` - removing this file signals service degradation
 
-> Note: In the near future, you will be able to specify the HTTP Path for the health-check.
+> Note: You can specify a custom HTTP Path for the health-check using the `com.openfaas.health.http.path` annotation
 
 If running in read-only mode, then you can write files to the `/tmp/` mount only. These files may be accessible upon subsequent requests but it is not guaranteed. For instance - if you have two replicas of a function then both may have different contents in their `/tmp/` mount. When running without read-only mode you can write files to the user's home directory subject to the same rules.
 
@@ -36,7 +36,6 @@ faas-cli new --list
 ```
 
 Or build your own templates Git repository and then pass that as an argument to `faas-cli template pull`
-
 
 ```
 faas-cli template pull https://github.com/my-org/templates
@@ -52,3 +51,27 @@ A stateless microservice can be built using the `dockerfile` language type and t
 An example of a stateless microservice may be an Express.js application using Node.js, a Sinatra app with Ruby or an ASP.NET 2.0 Core web-site.
 
 Use of the [OpenFaaS next-gen of-watchdog](https://github.com/openfaas-incubator/of-watchdog) is optional, but recommended for stateless microservices to provide a consistent experience for timeouts, logging and configuration.
+
+On Kubernetes is possible to run any container image as an OpenFaaS function as long as your application exposes port 8080 and has a HTTP health check endpoint.
+
+You can specify the HTTP path of your health check and the initial check delay duration with the following annotations:
+
+* `com.openfaas.health.http.path`
+* `om.openfaas.health.http.initialDelay`
+
+Stack file example:
+
+```yaml
+functions:
+  kubesec:
+    image: docker.io/stefanprodan/kubesec:v2.1
+    skip_build: true
+    annotations:
+      com.openfaas.health.http.path: "/healthz"
+      com.openfaas.health.http.initialDelay: "30s"
+``` 
+
+> Note: The initial delay value must be a valid Go duration e.g. `80s` or `3m`. 
+
+
+

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -192,6 +192,14 @@ Example of setting a "topic" for the Kafka event connector:
      expire-date: "Wed Aug  8 07:40:18 BST 2018"
 ```
 
+Example of setting a custom HTTP health check path and initial check delay:
+
+```yaml
+   annotations:
+     com.openfaas.health.http.path: "/healthz"
+     com.openfaas.health.http.initialDelay: "30s"
+```
+
 #### Function: Memory/CPU limits
 
 Applying memory and CPU limits can be done through the `limits` and `requests` [fields](https://godoc.org/github.com/openfaas/faas-cli/stack#FunctionResources). It is advisable to always set a limit for your functions to prevent them consuming too many resources in your system.


### PR DESCRIPTION
## Description

Add examples of setting a custom HTTP health check path and initial check delay using annotations. 

Ref: https://github.com/openfaas/faas-netes/issues/442
Depends on: https://github.com/openfaas/faas-netes/pull/447

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
