### PR TITLE
Amend the YAML reference description of requests

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -234,7 +234,7 @@ Here we constrain a function to use only `100m` which is equivalent to 1/10 of [
 
 The meanings and formats of `limits` and `requests` may vary depending on whether you are using Kubernetes or Docker Swarm. In general:
 
- - Reserve maintains the host resources to ensure that the container can use them
+ - Requests ensures the stated host resource is available for the container to use
  - Limits specify the maximum amount of host resources that a container can consume
 
 See docs for [Docker Swarm](https://docs.docker.com/config/containers/resource_constraints/) or for [Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-r    esource-limits-are-run).


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Minor change to wording around the requests field in the YAML reference

## Motivation and Context
It was referring to `reserve` rather than `request` which may lead to confusion for the reader.

No issue - trivial change to wording.

## How Has This Been Tested?
I've read it 3 times

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
