### PR TITLE
Fix dead link to self-hosting page

### DIFF
--- a/docs/openfaas-cloud/user-guide.md
+++ b/docs/openfaas-cloud/user-guide.md
@@ -2,7 +2,7 @@
 
 This guide applies to:
 
-* [OpenFaaS Cloud: Self-hosted](/openfaas-cloud/)
+* [OpenFaaS Cloud: Self-hosted](/openfaas-cloud/self-hosted/)
 * [OpenFaaS Cloud: The Community Cluster](/openfaas-cloud/community-cluster/)
 
 ## The guide


### PR DESCRIPTION
Observed issue from page:

https://docs.openfaas.com/openfaas-cloud/user-guide/

Link "OpenFaaS Cloud: Self-hosted" is broken :

https://docs.openfaas.com/openfaas-cloud/

URL is showing a 404 Error

So an Index page was added in self-hosting dir,
and link updated accordingly.

Change-Id: Ia9f2206afdd1eaa1d928f55456e80f14a2f10b9f
Signed-off-by: Philippe Coval <p.coval@samsung.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
