### PR TITLE
Make PR template more pertinent to docs changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [ ] My code follows the code style of this project.
 - [ ] I have tested any new instructions
-- [ ] I am the author 
-- [ ] I am not the author but have permission to share this text and have referenced the source
+- [ ] I have included copyrighted materials from third parties.
+- [ ] I have permission to use copyrighted materials from third parties.
 - [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
 - [ ] I have signed-off my commits with `git commit -s`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,21 +10,24 @@
 
 
 ## How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+ - [ ] I have tested the markdown appearance with Docker (Refer to the [local development instructions](https://github.com/openfaas/docs#local-development))
+<!--- Please include screenshots of the main areas of change.-->
+
 
 ## Types of changes
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+<!--- What types of changes are included? Put an `x` in one the boxes: -->
+<!--- Where new content covers a new feature please reference the PR for this feature -->
+
+- [ ] New Content
+- [ ] Content Correction
+- [ ] Content Improvement
+- [ ] Non-content (config/templates/mkdocs/CSS)
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] My code follows the code style of this project.
-- [ ] My change requires a change to the documentation.
-- [ ] I have updated the documentation accordingly.
+- [ ] I have tested any new instructions
+- [ ] I am the author 
+- [ ] I am not the author but have permission to share this text and have referenced the source
 - [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
 - [ ] I have signed-off my commits with `git commit -s`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the source repository for the OpenFaaS documentation site.
 
-For local development:
+## Local development:
 
 ```shell
 # docker run --rm -it -p 8000:8000 -v `pwd`:/docs squidfunk/mkdocs-material


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
 - Small change to README so that the local development section can be linked from the new template.
 - Pull in suggestions from the original issue and remove less relevant checklist items

## Motivation and Context
- [x] I have raised an issue to propose this change (fixes #9 )

## How Has This Been Tested?
Its an issue template

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
