### PR TITLE
Edit template store pull to a single arg

### DIFF
--- a/docs/cli/templates.md
+++ b/docs/cli/templates.md
@@ -55,7 +55,21 @@ csharp-httprequest      distantcam         C# HTTP template
 ...
 ```
 
-Choose one or more templates and pull them with the command `faas-cli template store pull node10-express ruby-http csharp` and your templates should be downloaded.
+Choose a template and retrieve it locally with the command:
+
+```sh
+$ faas-cli template store pull node10-express
+```  
+
+Once downloaded, your chosen template and any others stored in the same repository will be available to use:
+
+```sh
+$ faas-cli new --list
+Languages available as templates:
+- node10-express
+- node10-express-arm64
+- node10-express-armhf
+```
 
 You can add your own store just by specifying the `--url` flag for both commands to pull and list your custom templates store.
 


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
An example command for template store pull was showing multiple template names could be passed in one command.  This isn't the case.  This change remove the multiple commands

## Motivation and Context
The docs were inaccurate and was confusing people according to community feedback on Slack.

## How Has This Been Tested?
Run locally:

![image](https://user-images.githubusercontent.com/16418793/66411813-43c44280-e9ec-11e9-82e4-e0872c67b775.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
