### PR TITLE
Add k3sup instructions for OpenFaaS deployment

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -77,7 +77,7 @@ It is recommended that new users install OpenFaaS with `k3sup` which determines 
 
 #### A. Deploy with `k3sup` (fastest option)
 
-`k3sup` is a CLI tool that can install helm charts without using `tiller`, a component that is considered to be insecure by some companies.
+[`k3sup`](https://k3sup.dev) is a CLI tool that can install helm charts without using `tiller`, a component that is considered to be insecure by some companies.
 
 The `openfaas app` in `k3sup` will install OpenFaaS to a regular cloud computer, your laptop, a Raspberry Pi, or a 64-bit ARM machine.
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add k3sup instructions for OpenFaaS deployment

## Motivation and Context

These instructions simplify the need to use different YAML files
or to use only YAML with ARMHF and helm/tiller with x86_64.

## How Has This Been Tested?

Tested by the community.

## Types of changes

Docs

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`