### PR TITLE
Update yaml docs to show correct provider

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -31,7 +31,7 @@ functions:
 
 ### Provider
 
-The only valid value for provider `name` is `faas`.
+The only valid value for provider `name` is `openfaas`.
 
 #### Gateway
 


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description
<!--- Describe your changes in detail -->
yaml reference docs stated that "faas" was the only allowed provider, its now "openfaas" as faas was deprecated

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Spoke to Alex on slack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
