### PR TITLE
Fix link 'Reference: Asynchronous Functions' - Closes #205

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -4,7 +4,7 @@ The most common questions and user-issues can be resolved by reading the documen
 
 ## Asynchronous functions
 
-See also: [Reference: Asynchronous Functions](/reference/async)
+See also: [Reference: Asynchronous Functions](/docs/reference/async.md)
 
 ## Chaining / workflows
 


### PR DESCRIPTION
Signed-off-by: Andreas Amstutz <andreasamstutz@gmail.com>

## Description
Broken link

## Motivation and Context
- [x] I have raised an issue to propose this change ([Broken link from troubleshooting.md to async functions](https://github.com/openfaas/docs/issues/205))


## How Has This Been Tested?
I followed the link

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
