### PR TITLE
Revert link target to previous value

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -4,7 +4,7 @@ The most common questions and user-issues can be resolved by reading the documen
 
 ## Asynchronous functions
 
-See also: [Reference: Asynchronous Functions](/docs/reference/async.md)
+See also: [Reference: Asynchronous Functions](/reference/async)
 
 ## Chaining / workflows
 


### PR DESCRIPTION
This reverts commit 9111ad4b5da6e8c7ff50446cce454a02cde197f6.

Signed-off-by: Andreas Amstutz <andreasamstutz@gmail.com>

## Motivation and Context
My previous change resulted in a broken link in the generated and published docs.

- [x] I have raised an issue to propose this change ([Fix link 'Reference: Asynchronous Functions'](https://github.com/openfaas/docs/issues/205))

## How Has This Been Tested?
Rendered the documentation locally using Docker:
`docker run --rm -it -p 8000:8000 -v $(pwd):/docs squidfunk/mkdocs-material`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
