### PR TITLE
Add build_config part to the documentation

### DIFF
--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -100,11 +100,22 @@ The entries in the template's Dockerfile described in 1.0 above need to be prese
 
 ## 3.0 Pass custom build arguments
 
-You can pass `ARG` values to Docker via the CLI.
+You can pass `ARG` values to Docker in two ways:
+
+via the CLI:
 
 ```bash
 faas-cli build --build-arg ARGNAME1=argvalue1 --build-arg ARGNAME2=argvalue2
 ``` 
+
+or in YAML:
+
+```yaml
+build_config:
+  build_args:
+    ARGNAME1: argvalue1
+    ARGNAME2: argvalue2
+```
 
 Remeber to add any `ARG` values to the template's Dockerfile:
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -239,6 +239,26 @@ The meanings and formats of `limits` and `requests` may vary depending on whethe
 
 See docs for [Docker Swarm](https://docs.docker.com/config/containers/resource_constraints/) or for [Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-r    esource-limits-are-run).
 
+#### Function: Build Config
+
+The `build_config` field contains a sub-field of `build_args`. This `build_args` can be used to you to pass [Docker build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to the build process. The passed build-time variables are accessed like regular environment variables in the `Dockerfile` but, as mentioned in [Docker docs](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg), these values don’t persist in the intermediate or final images like `ENV` values do and can be specified differently depending on which host they build an image on. 
+
+For example, if you need 2 build-time variables `ARGNAME1` and `ARGNAME2` with the values of `argvalue1` and `argvalue2` respectively, you can specify
+
+```yaml
+build_config:
+  build_args:
+    ARGNAME1: argvalue1
+    ARGNAME2: argvalue2
+```
+
+Important note: The template author must specify [`ARG`](https://docs.docker.com/engine/reference/builder/#arg) accordingly in the `Dockerfile`.
+
+```dockerfile
+ARG ARGNAME1
+ARG ARGNAME2
+```
+
 ### YAML - environment variable substitution
 
 The YAML stack format supports the use of `envsubst`-style templates. This means that you can have a single file with multiple configuration options such as for different user accounts, versions or environments.


### PR DESCRIPTION

## Description
These changes will update the documentation and will guide the users about the usage of `build_config` and `build_args` in YAML stack file.

## Motivation and Context
To ensure reproducible and portable builds, we should support supplying build args via the YAML stack file.

Resolves: #687

- [X] An issue has been raised to propose this change


## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Update documentation

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
