### PR TITLE
Fix link to arkade in deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,7 +23,7 @@ Find out more [in the OpenFaaS architecture](https://docs.openfaas.com/architect
 
 There are three recommended ways to install OpenFaaS to a Kubernetes cluster:
 
-* Using the helm chart with our [arkade](https://arkade.dev/) installer, (recommended for dev/test)
+* Using the helm chart with our [arkade](https://get-arkade.dev/) installer, (recommended for dev/test)
 * Using the helm chart directly or [via Weave Flux](https://www.openfaas.com/blog/openfaas-flux/) - ideal for a GitOps/IaaC configuration
 * Using the plain YAML files - generated YAML which you will need to customise
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Fix the link to Arkade in the deployment docs so that it goes to the
  correct `http://get-arkade.dev`

It was previously going to this broken page

![image](https://user-images.githubusercontent.com/891889/76554535-57417100-6496-11ea-92e2-118e0bfb5753.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
NA, just mentioned it in slack and this is a very small fix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Previewed the page locally and also grepped the project to verify all of the links matched

![image](https://user-images.githubusercontent.com/891889/76554486-4133b080-6496-11ea-897f-b43e2dab9ca8.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
