### PR TITLE
Fix a link to point to real page

### DIFF
--- a/docs/openfaas-cloud/user-guide.md
+++ b/docs/openfaas-cloud/user-guide.md
@@ -2,7 +2,7 @@
 
 This guide applies to:
 
-* [OpenFaaS Cloud: Self-hosted](/openfaas-cloud/self-hosted/)
+* [OpenFaaS Cloud: Self-hosted](/openfaas-cloud/self-hosted/github)
 * [OpenFaaS Cloud: The Community Cluster](/openfaas-cloud/community-cluster/)
 
 ## The guide


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

The docs were split into github and gitlab forOFC I think, this link
pointed at "self-hosted" which was split into "self-hosted/github" and
"self-hosted/gitlab"

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran the docs locally & checked the link worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
