### PR TITLE
Add namespace override example

### DIFF
--- a/docs/reference/namespaces.md
+++ b/docs/reference/namespaces.md
@@ -102,3 +102,11 @@ faas-cli deploy
 
 head -c 16 /dev/urandom | faas-cli invoke --namespace dev stronghash
 ```
+
+Override the namespace configured in the stack.yml when deploying the function and test:
+
+```sh
+faas-cli deploy --namespace staging-fn
+
+head -c 16 /dev/urandom | faas-cli invoke --namespace staging-fn stronghash
+```


### PR DESCRIPTION
Adding namespace override to the examples when
there is dev in the stack.yml and during deployment
you override the namespace with the cli

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add namespace override to examples

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Trello: https://trello.com/c/dIg2XqMJ/128-add-namespace-override-examples-to-docs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This is document change, but I tested the scenario.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Example addition

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
