### PR TITLE
Update cronjob examples to allow entrypoint images

### DIFF
--- a/docs/reference/cron.md
+++ b/docs/reference/cron.md
@@ -54,8 +54,9 @@ spec:
           containers:
           - name: openfaas-cli
             image: openfaas/faas-cli:0.8.3
-            args:
+            command:
             - /bin/sh
+            args:
             - -c
             - echo "verbose" | faas-cli invoke nodeinfo -g http://gateway.openfaas:8080
           restartPolicy: OnFailure
@@ -172,8 +173,9 @@ spec:
                   secretKeyRef:
                     name: basic-auth
                     key: basic-auth-password
-            args:
+            command:
             - /bin/sh
+            args:
             - -c
             - echo -n $PASSWORD | faas-cli login -g http://gateway.openfaas:8080 -u $USERNAME --password-stdin
             - echo "verbose" | faas-cli invoke nodeinfo -g http://gateway.openfaas:8080


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Move the `/bin/sh` to the `command` field so that it defines the
  container entrypoint as the shell. This is the most robust way to
  define these jobs and supports the new `faas-cli` docker image that
  sets `faas-cli` as the entrypoint
- Reference https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
openfaas/faas-cli#818

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
