### PR TITLE
fix: python3-debian graduated from incubator

### DIFF
--- a/docs/cli/templates.md
+++ b/docs/cli/templates.md
@@ -270,7 +270,7 @@ The primary Python template uses Alpine Linux as a runtime environment due to it
 If you need to use pip modules that require compilation then you should try the python3-debian template then add your pip modules to the `requirements.txt` file.
 
 ```
-$ faas-cli template pull https://github.com/openfaas-incubator/python3-debian
+$ faas-cli template pull
 $ faas-cli new numpy-function --lang python3-debian
 $ echo "numpy" > ./numpy-function/requirements.txt
 $ faas-build -f ./numpy-function.yml


### PR DESCRIPTION
As python3-debian graduated from incubator (see https://github.com/openfaas/templates/commit/b0b4dcd), the docs should no make use of the former (now archived) repository.

BTW: I mostly ignored your pull request template, sorry. Just felt like this was such a minor change.