### PR TITLE
Update kubernetes-hpa.md

### DIFF
--- a/docs/tutorials/kubernetes-hpa.md
+++ b/docs/tutorials/kubernetes-hpa.md
@@ -243,7 +243,7 @@ You should note that HPA is designed to react slowly to changes in traffic, both
 Now in a new window monitor the progress:
 
 ```sh
-kubectl describe hpa/nodeinfo -n openfaas
+kubectl describe hpa/nodeinfo -n openfaas-fn
 ```
 
 Or in an automated fashion:


### PR DESCRIPTION
The namespace should be openfaas-fn otherwise you wont get your hpa information. 

As the command was you will get this error:
kubectl describe hpa/nodeinfo -n openfaas
Error from server (NotFound): horizontalpodautoscalers.autoscaling "nodeinfo" not found

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
