### PR TITLE
Fix k8s with cert-manager docs old references to tiller and nginx-ingress

### DIFF
--- a/docs/reference/ssl/kubernetes-with-cert-manager.md
+++ b/docs/reference/ssl/kubernetes-with-cert-manager.md
@@ -5,7 +5,7 @@ You can obtain TLS certificates for the OpenFaaS API Gateway and for your functi
 We will use the following components:
 
  - [Nginx IngressController][nginx-ingress]
- - OpenFaaS installed via [helm][openfaas-helm] or (`helm template` if you can't use `tiller`)
+ - OpenFaaS installed via [helm][openfaas-helm]
  - [cert-manager][cert-manager]
 
 We will split this tutorial into two parts:

--- a/docs/reference/ssl/kubernetes-with-cert-manager.md
+++ b/docs/reference/ssl/kubernetes-with-cert-manager.md
@@ -4,9 +4,9 @@ You can obtain TLS certificates for the OpenFaaS API Gateway and for your functi
 
 We will use the following components:
 
+ - [Nginx IngressController][nginx-ingress]
  - OpenFaaS installed via [helm][openfaas-helm] or (`helm template` if you can't use `tiller`)
  - [cert-manager][cert-manager]
- - [Nginx IngressController][nginx-ingress]
 
 We will split this tutorial into two parts:
 
@@ -17,13 +17,9 @@ We will split this tutorial into two parts:
 
 This part guides you through setting up all the pre-requisite components to enable TLS for your gateway. You can then access your gateway via a URL such as `https://gw.example.com` and each function such as: `https://gw.example.com/function/nodeinfo`.
 
-### Configure Helm and Tiller
+### Configure Helm
 
-First install Helm and the Tiller [following the instructions provided by Helm][helm-install]
-
-### Install OpenFaaS
-
-Follow the instructions found in the [OpenFaaS Helm Chart](https://github.com/openfaas/faas-netes/tree/master/chart/openfaas#deploy-openfaas). As part of these instructions you will create a basic-auth password to secure the Gateway's API and UI.
+First install Helm v3 [following the instructions provided by Helm][helm-install]
 
 ### Install nginx-ingress
 
@@ -32,7 +28,8 @@ This example will use a Kubernetes [IngressController](https://kubernetes.io/doc
 Add Nginx using the helm `chart-ingress`:
 
 ```sh
-$ helm install stable/nginx-ingress --name nginxingress --set rbac.create=true
+$ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+$ helm install nginxingress ingress-nginx/ingress-nginx
 ```
 
 The full configuration options for nginx [can be found here][nginx-configuration].
@@ -46,10 +43,16 @@ nginxingress-nginx-ingress-controller        LoadBalancer   192.168.137.172   13
 
 Caveats: 
 
+* Alternatively, use [arkade](https://github.com/alexellis/arkade) to install nginx-ingress.
+
+  ```sh
+  arkade install ingress-nginx
+  ```
+
 * If you do not have a cloud provider for your Kubernetes cluster, but have a public IP, then you can install Nginx in "host-mode" and use the IP of one or more of your nodes for the DNS record.
 
   ```sh
-  $ helm install stable/nginx-ingress --name nginxingress --set rbac.create=true,controller.hostNetwork=true controller.daemonset.useHostPort=true,dnsPolicy=ClusterFirstWithHostNet,controller.kind=DaemonSet
+  $ helm install  nginxingress ingress-nginx/ingress-nginx --set rbac.create=true,controller.hostNetwork=true controller.daemonset.useHostPort=true,dnsPolicy=ClusterFirstWithHostNet,controller.kind=DaemonSet
   ```
 
   Taken from tutorial: [Setup a private Docker registry with TLS on Kubernetes](https://github.com/alexellis/k8s-tls-registry)
@@ -57,6 +60,16 @@ Caveats:
 * If you do not have a public IP for your Kubernetes cluster, then you can use a project like [Inlets](https://inlets.dev) and bypass using cert-manager. Inlets has around half a dozen examples of configurations for Kubernetes.
 
   [HTTPS for your local endpoints with inlets and Caddy](https://blog.alexellis.io/https-inlets-local-endpoints/)
+
+### Install OpenFaaS
+
+Follow the instructions found in the [OpenFaaS Helm Chart](https://github.com/openfaas/faas-netes/tree/master/chart/openfaas#deploy-openfaas). As part of these instructions you will create a basic-auth password to secure the Gateway's API and UI.
+
+Alternatively, use [arkade](https://github.com/alexellis/arkade) to install openfaas:
+
+  ```sh
+  arkade install openfaas
+  ```
 
 ### Create a DNS record
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #244 
Minor updates to install docs for openfaas on k8s with cert-manager.
Helm v3 does not use tiller.  Nginx-ingress helm chart command needed
updating.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves minor confusion when executing these docs using current helm.

<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #244 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested new docs on Digital Ocean K8S 1.18.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
