### PR TITLE
Move ofc-bootstrap to openfaas org

### DIFF
--- a/docs/contributing/code-repositories.md
+++ b/docs/contributing/code-repositories.md
@@ -21,6 +21,7 @@ For this reason you should always collate statistics from the `openfaas` organis
 | [media](https://github.com/openfaas/media)             | Press-kit and media for the project branding and swag             |
 | [openfaas.github.io](https://github.com/openfaas/openfaas.github.io)               | Source for https://www.openfaas.com and blog |
 | [openfaas-cloud](https://github.com/openfaas/openfaas-cloud)        | OpenFaaS Cloud - portable, multi-user Serverless Functions powered by GitOps |
+| [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap) | "one-click" CLI to install OpenFaaS Cloud on Kubernetes |
 | [workshop](https://github.com/openfaas/workshop)             | Practical training and hands-on labs for learning OpenFaaS |
 
 ### OpenFaaS Incubator
@@ -35,7 +36,6 @@ Some people have wrongly assumed that the "incubator" organisation means that th
 | [faas-idler](https://github.com/openfaas-incubator/faas-idler)         | Scale OpenFaaS functions to zero replicas after specified period of inactivity   |
 | [openfaas-operator](https://github.com/openfaas-incubator/openfaas-operator)         | The OpenFaaS CRD Operator for Kubernetes   |
 | [kafka-connector](https://github.com/openfaas-incubator/kafka-connector)         | The Kafka connector connects OpenFaaS functions to Kafka topics   |
-| [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap) | "one-click" CLI to install OpenFaaS Cloud on Kubernetes |
 | [ingress-operator](https://github.com/openfaas-incubator/ingress-operator/) | Provides `FunctionIngress` CRD for Custom Domains on Kubernetes |
 | [connector-sdk](https://github.com/openfaas-incubator/connector-sdk)         | Build your own event connectors for OpenFaaS |
 | [vcenter-connector](https://github.com/openfaas-incubator/vcenter-connector) | Trigger OpenFaaS Functions from events in VMware vCenter |

--- a/docs/openfaas-cloud/intro.md
+++ b/docs/openfaas-cloud/intro.md
@@ -49,5 +49,5 @@ See also: [Apply for Access](https://github.com/openfaas/community-cluster)
 
 OpenFaaS Cloud is open source software which you can use to host your OpenFaaS Cloud cluster. OpenFaaS Cloud brings a managed, multi-user experience with built-in dashboard and CI/CD. This lowers the barrier to entry for teams, meaning that developers only need to know how to use git and require no pre-assumed knowledge of Docker or Kubernetes.
 
-* For an automated quick-start use [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap) to provision OpenFaaS Cloud in 100 seconds on Kubernetes [Video demo](https://www.youtube.com/watch?v=Sa1VBSfVpK0)
+* For an automated quick-start use [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap) to provision OpenFaaS Cloud in 100 seconds on Kubernetes [Video demo](https://www.youtube.com/watch?v=Sa1VBSfVpK0)
 * Or start the [Developer guide](https://github.com/openfaas/openfaas-cloud/tree/master/docs) for a manual installation or to use Docker Swarm

--- a/docs/openfaas-cloud/multi-stage.md
+++ b/docs/openfaas-cloud/multi-stage.md
@@ -18,7 +18,7 @@ Staging is deployed from the `staging` branch.
 
 #### Configuration
 
-Install OpenFaaS Cloud with [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap), once for each environment on separate clusters. Some configuration in `init.yaml` needs to be changed, other settings can remain the same:
+Install OpenFaaS Cloud with [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap), once for each environment on separate clusters. Some configuration in `init.yaml` needs to be changed, other settings can remain the same:
 
 * Set the `root_domain`
 

--- a/docs/openfaas-cloud/self-hosted/github.md
+++ b/docs/openfaas-cloud/self-hosted/github.md
@@ -60,7 +60,7 @@ We will cover creating and configuring a GitHub App for webhooks and events and 
 
 It is highly recommended to enable authentication through OAuth. To set it up follow the steps in the next section. If you have decided not to configure OAuth then you can finish here.
 
-That's it, you can now input this data into the [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap) 1-click tool, or follow the developer instructions in the [openfaas-cloud](https://github.com/openfaas/openfaas-cloud/tree/master/docs) repo.
+That's it, you can now input this data into the [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap) 1-click tool, or follow the developer instructions in the [openfaas-cloud](https://github.com/openfaas/openfaas-cloud/tree/master/docs) repo.
 
 ### Create a GitHub OAuth integration (optional)
 
@@ -86,4 +86,4 @@ We will now create a GitHub OAuth integration so that we and our users can log i
 
     ![](/images/openfaas-cloud/github-oauth-02.png)
 
-That's it, you can now input this data into the [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap) 1-click tool, or follow the developer instructions in the [openfaas-cloud](https://github.com/openfaas/openfaas-cloud/tree/master/docs) repo.
+That's it, you can now input this data into the [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap) 1-click tool, or follow the developer instructions in the [openfaas-cloud](https://github.com/openfaas/openfaas-cloud/tree/master/docs) repo.

--- a/docs/openfaas-cloud/self-hosted/gitlab.md
+++ b/docs/openfaas-cloud/self-hosted/gitlab.md
@@ -2,7 +2,7 @@
 
 This guide is for connecting your own self-hosted GitLab instance to your OpenFaaS Cloud deployment.
 
-Use this guide to configure your `init.yaml` file for use with [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap).
+Use this guide to configure your `init.yaml` file for use with [ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap).
 
 ### Edit your init.yaml file
 

--- a/docs/openfaas-cloud/self-hosted/troubleshoot.md
+++ b/docs/openfaas-cloud/self-hosted/troubleshoot.md
@@ -56,7 +56,7 @@ Useful commands:
 
 #### Something else not working?
 
-Make sure that you clearly followed all the instructions in the [README for ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/README.md), read them through and check them off one-by-one.
+Make sure that you clearly followed all the instructions in the [README for ofc-bootstrap](https://github.com/openfaas/ofc-bootstrap/blob/master/README.md), read them through and check them off one-by-one.
 
 Make sure that you edited `init.yaml`, read all the comments and updated the values that you needed to. If in doubt, ask questions on Slack.
 


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description
<!--- Describe your changes in detail -->
Move ofc-bootstrap refs into main of org


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
ofc bootstrap has moved into the main of org

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
