### PR TITLE
End free support for Swarm

### DIFF
--- a/docs/architecture/autoscaling.md
+++ b/docs/architecture/autoscaling.md
@@ -53,7 +53,7 @@ For a technical overview see the blog post: [Scale to Zero and Back Again with O
 
 ### Scaling up from zero replicas
 
-Scaling up from zero replicas or 0/0 can be toggled through the `scale_from_zero` environment variable for the OpenFaaS Gateway. This is turned on by default for both Kubernetes and Docker Swarm.
+Scaling up from zero replicas or 0/0 can be toggled through the `scale_from_zero` environment variable for the OpenFaaS Gateway. This is turned on by default on Kubernetes and faasd.
 
 The latency between accepting a request for an unavailable function and serving the request is sometimes called a "Cold Start".
 

--- a/docs/architecture/production.md
+++ b/docs/architecture/production.md
@@ -8,7 +8,7 @@ When deploying OpenFaaS it is recommended that you use [Kubernetes](https://kube
 
 These instructions apply for both Kubernetes and OpenShift 3.x.
 
-> Note: Docker Swarm and other providers are available, but are beyond the scope of this document.
+> Note: Docker Swarm is not supported for production use.
 
 ### Advanced Kubernetes configuration
 

--- a/docs/contributing/get-started.md
+++ b/docs/contributing/get-started.md
@@ -37,7 +37,6 @@ If you are new with Docker, Kubernetes, or Go and would like to learn or just im
     * [Tutorials from Alex Ellis](https://blog.alexellis.io/tag/kubernetes/)
 * **Docker**
     * [Docker Documentation](https://docs.docker.com)
-    * [Docker Swarm Documentation](https://docs.docker.com/engine/swarm/)
 * [Travis CI User Documentation](https://docs.travis-ci.com)
 
 ## Communicate with the community

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,13 +54,13 @@ You can deploy to OpenShift using our CLI installer <a href="https://get-arkade.
 
 [Deploy to OpenShift](/deployment/openshift/)
 
-## Docker Swarm
+## Docker Swarm (deprecated)
 
-!!! warning "A foreword on security"
-    Bear in mind that Docker Swarm is widely consider to be approaching "End of Life". Kubernetes with <a href="https://k3s.io">k3s.io</a>, or faasd (above) may make a better alternative for you and your team.
+!!! warning "Deprecation of free community support"
+    Free community support for Docker Swarm has been discontinued. If you run Docker Swarm and OpenFaaS in your business and require continued support, then [contact support](https://openfaas.com/support/) as soon as you can.
 
-If you prefer to use Docker Swarm, then follow the [deployment guide Docker Swarm](/deployment/docker-swarm/).
+Why has this decision been made? Docker Swarm is widely consider to be "End of Life" product. Projects like Kubernetes have a much broader ecosystem and are receiving continual investment from their respective communities.
 
-### Docker Swarm Playground
+If you were attracted to Docker Swarm because you believe it to be easier to manage than Kubernetes, we recommend taking a look at a managed Kubernetes service, or [k3s.io](https://k3s.io).
 
-If you cannot run Docker on your local machine, or can't install anything locally, then you can try OpenFaaS on play-with-docker.com (PWD). Follow the [playground guide here](/deployment/play-with-docker/)
+If you need next to no operations, then faasd (above) should be the top of your list.

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -22,6 +22,8 @@ The default address for the gateway on Kubernetes is `http://gateway.openfaas:80
 
 ### On Docker Swarm
 
+> Note: Free community support for Docker Swarm is deprecated.
+
 The default address for the gateway is `http://gateway:8080`
 
 ## Error with "faas" provider

--- a/docs/faasd.md
+++ b/docs/faasd.md
@@ -1,0 +1,34 @@
+# faasd deployment - a lightweight & portable faas engine
+
+faasd is [OpenFaaS](https://github.com/openfaas/) reimagined, but without the cost and complexity of Kubernetes. It runs on a single host with very modest requirements, making it fast and easy to manage. Under the hood it uses [containerd](https://containerd.io/) and [Container Networking Interface (CNI)](https://github.com/containernetworking/cni) along with the same core OpenFaaS components from the main project.
+
+## When should you use faasd over OpenFaaS on Kubernetes?
+
+* You have a cost sensitive project - run faasd on a 5-10 USD VPS or on your Raspberry Pi
+* When you just need a few functions or microservices, without the cost of a cluster
+* When you don't have the bandwidth to learn or manage Kubernetes
+* To deploy embedded apps in IoT and edge use-cases
+* To shrink-wrap applications for use with a customer or client
+
+faasd does not create the same maintenance burden you'll find with maintaining, upgrading, and securing a Kubernetes cluster. You can deploy it and walk away, in the worst case, just deploy a new VM and deploy your functions again.
+
+## Deployment
+
+faasd is a static binary which requires a Linux system configured with systemd.
+
+Minimal system resources are required such as:
+* 512MB-1GB RAM
+* 1-4 vCPU cores
+* 10-25GB of disk space
+* The Raspberry Pi 3 and 4 are also supported
+
+Local development/testing:
+* Windows and Mac users can use multipass to deploy faasd in a VM
+* Linux users can deploy faasd directly, or also use multipass
+
+Production use:
+* Use the bash installation script
+* Deploy using the provided cloud-init script
+* Deploy using terraform, or adapt the terraform examples
+
+See the [project README](https://github.com/openfaas/faasd/) for more.

--- a/docs/openfaas-cloud/intro.md
+++ b/docs/openfaas-cloud/intro.md
@@ -44,4 +44,4 @@ OpenFaaS Cloud is for anyone who wants to focus on shipping functions without wo
 OpenFaaS Cloud is open source software which you can use to host your OpenFaaS Cloud cluster. OpenFaaS Cloud brings a managed, multi-user experience with built-in dashboard and CI/CD. This lowers the barrier to entry for teams, meaning that developers only need to know how to use git and require no pre-assumed knowledge of Docker or Kubernetes.
 
 * For an automated quick-start use [ofc-bootstrap](https://github.com/openfaas-incubator/ofc-bootstrap) to provision OpenFaaS Cloud in 100 seconds on Kubernetes [Video demo](https://www.youtube.com/watch?v=Sa1VBSfVpK0)
-* Or start the [Developer guide](https://github.com/openfaas/openfaas-cloud/tree/master/docs) for a manual installation or to use Docker Swarm
+* Or start the [Developer guide](https://github.com/openfaas/openfaas-cloud/tree/master/docs) for a manual installation.

--- a/docs/reference/cicd/intro.md
+++ b/docs/reference/cicd/intro.md
@@ -10,7 +10,7 @@ See also: [OpenFaaS Cloud](../../../openfaas-cloud/intro/)
 
 ### Use the native `faas-cli`
 
-It is recommended to use the `faas-cli` binary for building and deploying your functions whether that is to Kubernetes or Docker Swarm.
+It is recommended to use the `faas-cli` binary for building and deploying your functions whether that is to Kubernetes or faasd.
 
 * Build only:
     ```

--- a/docs/reference/cron.md
+++ b/docs/reference/cron.md
@@ -225,9 +225,9 @@ To stop the invocations, remove the two annotations or remove the cron-connector
 
 If you would like to explore how to write CRON expressions, then see [https://crontab.guru/](https://crontab.guru/)
 
-## Docker Swarm
+## faasd
 
-Docker Swarm has no concepts of scheduled tasks or cron, but we have a suitable recommendation which you can use with your OpenFaaS cluster. If you deploy a Jenkins master service, then you can use that to manage your scheduled tasks. It will handle distributed locking, concurrency and queueing.
+faasd has no concepts of scheduled tasks or cron, but we have a suitable recommendation which you can use with your OpenFaaS cluster. If you deploy a Jenkins master service, then you can use that to manage your scheduled tasks. It will handle distributed locking, concurrency and queueing.
 
 Example usage:
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -139,7 +139,7 @@ environment:
 
 ### Function: Secure secrets
 
-OpenFaaS functions can make use of secure secrets using the secret store from Kubernetes or Docker Swarm. This is the recommended way to store secure access keys, tokens and other private data.
+OpenFaaS functions can make use of secure secrets using the secret store from Kubernetes or faasd. This is the recommended way to store secure access keys, tokens and other private data.
 
 Create the secret with your orchestration tool i.e. `kubectl` or `docker secret create` then list the secret name as part of an array of secrets.
 

--- a/docs/tutorials/CLI-with-node.md
+++ b/docs/tutorials/CLI-with-node.md
@@ -24,8 +24,6 @@ Before starting you should setup OpenFaaS on your laptop or cluster using a depl
 
 [Deployment guide](http://docs.openfaas.com/deployment/)
 
-If you're not sure which to pick - you can deploy and setup Docker Swarm in around 60 seconds.
-
 ### Get the CLI
 
 For the latest version of the CLI type in the following:

--- a/docs/tutorials/featured.md
+++ b/docs/tutorials/featured.md
@@ -42,6 +42,7 @@ See also: [performance testing](/architecture/performance/) and [going to produc
 
 ## ARM / Raspberry Pi
 
+* [Walk-through — install Kubernetes to your Raspberry Pi in 15 minutes](https://medium.com/@alexellisuk/walk-through-install-kubernetes-to-your-raspberry-pi-in-15-minutes-84a8492dc95a?postPublishedType=repub)
 * [Will it cluster? k3s on your Raspberry Pi](https://blog.alexellis.io/test-drive-k3s-on-raspberry-pi/) - build a lightweight cluster using Rancher's k3s Kubernetes distribution
 * [Kubernetes on Raspbian](https://github.com/alexellis/k8s-on-raspbian)
 * [Build your own bare-metal ARM cluster](https://blog.alexellis.io/build-your-own-bare-metal-arm-cluster/)

--- a/docs/tutorials/test-drive.md
+++ b/docs/tutorials/test-drive.md
@@ -12,7 +12,7 @@ OpenFaaS (or Functions as a Service) is a framework for building serverless func
 
 > Please support the project and put a **Star** on the repo.
 
-OpenFaaS is Kubernetes and Docker-native.
+OpenFaaS runs natively on Kubernetes and uses OCI-compatible containers.
 
 # Overview
 

--- a/docs/tutorials/test-drive.md
+++ b/docs/tutorials/test-drive.md
@@ -8,11 +8,11 @@ Please start [Lab 1 here](https://github.com/openfaas/workshop)
 
 ## TestDrive (v1 - classic version)
 
-OpenFaaS (or Functions as a Service) is a framework for building serverless functions on Docker Swarm and Kubernetes with first class metrics. Any UNIX process can be packaged as a function in FaaS enabling you to consume a range of web events without repetitive boiler-plate coding.
+OpenFaaS (or Functions as a Service) is a framework for building serverless functions on Kubernetes and faasd with first class metrics. Any UNIX process can be packaged as a function in FaaS enabling you to consume a range of web events without repetitive boiler-plate coding.
 
 > Please support the project and put a **Star** on the repo.
 
-OpenFaaS is Kubernetes and Docker-native. In this test-drive we'll be using Docker Inc's online lab for Docker Swarm called play-with-docker.
+OpenFaaS is Kubernetes and Docker-native.
 
 # Overview
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,9 +110,8 @@ nav:
   - Getting Started:
       - Deployment: deployment.md
       - Kubernetes: ./deployment/kubernetes.md
+      - faasd: ./deployment/faasd.md
       - OpenShift: ./deployment/openshift.md
-      - Docker Swarm: ./deployment/docker-swarm.md
-      - Docker Playground: ./deployment/play-with-docker.md
       - Troubleshooting: ./deployment/troubleshooting.md
   - CLI:
       - Installation: ./cli/install.md
@@ -165,7 +164,6 @@ nav:
       - Expanded timeouts: ./tutorials/expanded-timeouts.md
       - CLI with Node.js: ./tutorials/CLI-with-node.md
       - First Python Function: ./tutorials/first-python-function.md
-      - Test Drive: ./tutorials/test-drive.md
       - Kubernetes HPAv2: ./tutorials/kubernetes-hpa.md
       - Kubernetes HPAv2 Custom Metrics: ./tutorials/kubernetes-hpa-custom-metrics.md
       - Local Registry with KinD: ./tutorials/local-kind-registry.md


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

End free support for Swarm

## Motivation and Context

We have made a concerted effort to inform users through Insiders' Updates, Twitter, Slack and the docs that we cannot offer continued free support for Docker Swarm.

The Kubernetes ecosystem is much richer and receives regular updates.

If a company using Swarm in production needs help, OpenFaaS Ltd can help them migrate to another solution like faasd or k3s.

This change is being made to improve the level of free community support volunteers can offer on Slack and to the community in general. 