### PR TITLE
Reference GHCR for faas-cli image

### DIFF
--- a/docs/reference/cron.md
+++ b/docs/reference/cron.md
@@ -37,7 +37,7 @@ spec:
         spec:
           containers:
           - name: openfaas-cli
-            image: openfaas/faas-cli:latest
+            image: ghcr.io/openfaas/faas-cli:latest
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh
@@ -47,7 +47,7 @@ spec:
           restartPolicy: OnFailure
 ```
 
-You should also update the `image` to the latest version of the `faas-cli` available found via the [Docker Hub](https://hub.docker.com/r/openfaas/faas-cli/tags/) or [faas-cli releases](https://github.com/openfaas/faas-cli/releases) page.
+You should also update the `image` to the latest version of the `faas-cli` available found via the [GitHub Container Registry](https://github.com/orgs/openfaas/packages/container/package/faas-cli) or [faas-cli releases](https://github.com/openfaas/faas-cli/releases) page.
 
 The important thing to notice is that we are using a Docker container with the `faas-cli` to invoke the function. This keeps the job very generic.
 
@@ -147,7 +147,7 @@ spec:
         spec:
           containers:
           - name: openfaas-cli
-            image: openfaas/faas-cli:latest
+            image: ghcr.io/openfaas/faas-cli:latest
             env:
               - name: USERNAME
                 valueFrom:


### PR DESCRIPTION
## Description
This updates the documentation for the cron reference where it mentions the `faas-cli` container image to use the GitHub Container Registry, as now the image is published there.

## Motivation and Context
With GHCR images referenced elsewhere in documentation, this PR brings inline with those changes.

## How Has This Been Tested?
I applied the example kubernetes yaml cronjob with the updated image reference and I was able to successfully trigger cronjobs that ran the `faas-cli` command.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
