### PR TITLE
add note for kubernetes constraints/nodeSelectors

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -161,9 +161,9 @@ This an optional boolean field, set to `false` by default.
 
 ### Function: Constraints
 
-Constraints are passed directly to the underlying container orchestrator. They allow you to pin a function to certain host or type of host.
+Constraints are passed _directly_ to the underlying container orchestrator. They allow you to pin a function to certain host or type of host.
 
-Here is an example of picking only hosts with a Linux OS in Docker Swarm:
+Here is an example of picking only hosts with a Linux OS in _Docker Swarm_:
 
 ```yaml
    constraints:
@@ -176,6 +176,8 @@ Or only using nodes running with Windows:
    constraints:
      - "node.platform.os == windows"
 ```
+
+> Important note: The constraints for Kubernetes must be [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)s in the format "<label-key>=<label-value>"
 
 ### Function: Labels
 
@@ -255,7 +257,7 @@ The meanings and formats of `limits` and `requests` may vary depending on whethe
  - Requests ensures the stated host resource is available for the container to use
  - Limits specify the maximum amount of host resources that a container can consume
 
-See docs for [Docker Swarm](https://docs.docker.com/config/containers/resource_constraints/) or for [Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-r    esource-limits-are-run).
+See docs for [Docker Swarm](https://docs.docker.com/config/containers/resource_constraints/) or for [Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-limits-are-run).
 
 ## Configuration
 The configuration section allows you to define additional configuration that is global to the entire stack, currently this mostly impacts function build time options.


### PR DESCRIPTION
## Description
The Kubernetes operator `faas-netes` expects the constraints / nodeSelectors in the format `<label-key>=<label-value>`.

References:
- Pull Request ([Node selector support via constraints #77](https://github.com/openfaas/faas-netes/pull/77)), which introduced the feature
- the [source code for the createSelector function](https://github.com/openfaas/faas-netes/blame/master/pkg/handlers/deploy.go#L338), see how the key-value pair is split
- an [issue](https://github.com/openfaas/faas-netes/issues/406#issuecomment-501236503) regarding the difference between constraints for Docker Swarm & Kubernetes

also remove some erroneous white space in an URL, which broke the link and anchor

## Motivation and Context
Clarify the constraints format for different container orchestrators, as this is stumbling block for some users, see [openfaas/faas-netes #406: Help needed with constraints](https://github.com/openfaas/faas-netes/issues/406)


## How Has This Been Tested?
I looked over the rendered markdown.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Improve Documentation

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
