### PR TITLE
Add namespace option to secrets docs

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -2,32 +2,53 @@
 
 The OpenFaaS CLI allows you to create, update, list and delete secrets using `faas-cli` instead of Docker or Kubernetes command line tools.
 
-The reason behind this is to give you simplicity when you need to use secrets for your functions as well as to provide a layer of abstraction, as it will work for both Kubernetes and Docker Swarm.
+The reason behind this is to give you simplicity when you need to use secrets for your functions as well as to provide a layer of abstraction, as it will work for both Kubernetes and [faasd](/deployment/faasd/).
+
+See also: `faas-cli secret --help`
 
 ## Create
 
 To create a secret from stdin, you can run:
 
-```
+```bash
 faas-cli secret create secret-name
 ```
-or use pipe instead:
+
+Or pipe the value from a file instead:
+
 ```
 cat 04385e5c413c10ed68afb010ebe8c5dd706aa20a | faas-cli secret create secret-name
 cat ~/Downloads/derek.pem | faas-cli secret create secret-name
 ```
 
 If you want to pass a value then do:
-```
-faas-cli secret create secret-name --from-literal="04385e5c413c10ed68afb010ebe8c5dd706aa20a"
+
+```bash
+faas-cli secret create secret-name \
+  --from-literal="04385e5c413c10ed68afb010ebe8c5dd706aa20a"
 ```
 
 To create it from file use:
-```
-faas-cli secret create secret-name --from-file=~/Downloads/derek.pem
+
+```bash
+faas-cli secret create secret-name \
+  --from-file=~/Downloads/derek.pem
 ```
 
+Target a specific namespace:
+
+```bash
+faas-cli secret create \ 
+  --namespace staging-fn \
+  secret-name \
+  --from-literal="04385e5c413c10ed68afb010ebe8c5dd706aa20a"
+```
+
+Note: you will need to follow the instructions for [multiple namespaces](/reference/namespaces) for the above command.
+
 You can pass `--gateway` flag if you'd like to create the secret for a specific OpenFaaS instance.
+
+See also: `faas-cli secret create --help`
 
 ## Update
 
@@ -51,36 +72,58 @@ From file:
 faas-cli secret update secret-name --from-file=~/Downloads/derek.pem
 ```
 
+See also: `faas-cli secret update --help`
+
 ## List
 
+To list secrets in the default namespace:
+
+```bash
+faas-cli secret list
+faas-cli secret ls
+```
+
+To list secrets in an alternative namespace:
+
+```bash
+faas-cli secret ls --namespace staging
+```
+
 To list secrets for an OpenFaaS instance use:
-```
-faas-cli secret list --gateway http://127.0.0.1:8080
-```
-or
-```
+
+```bash
 faas-cli secret ls --gateway http://127.0.0.1:8080
 ```
-If you have set $OPENFAAS_URL you can use only 
-```
+
+If you have set `$OPENFAAS_URL` you can use only
+
+```bash
 faas-cli secret ls
 ```
 
 This will output:
-```
+
+```bash
 NAME
 secret-name1
 secret-name2
 ...
 ```
 
+See also: `faas-cli secret list --help`
+
 ## Delete
 
 You can delete secrets with:
-```
+```bash
 faas-cli secret remove secret-name
 ```
+
 or
+
+```bash
+faas-cli secret remove secret-name \
+  --gateway=http://127.0.0.1:8080
 ```
-faas-cli secret remove secret-name --gateway=http://127.0.0.1:8080
-```
+
+See also: `faas-cli secret delete --help`


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add namespace option to secrets docs
## Motivation and Context

A user on Slack was confused and didn't check the --help flag.
He assumed that because the docs didn't mention namespace, that
it wasn't possible to specify one. This commit makes it clearer
that one can use a namespace with secrets, when the feature is
enabled.

## How Has This Been Tested?

Local testing with Docker for the two new links and for rendering
