### PR TITLE
Remove references to using dep in the go templates

### DIFF
--- a/docs/cli/templates.md
+++ b/docs/cli/templates.md
@@ -61,7 +61,7 @@ Choose a template and retrieve it locally with the command:
 
 ```sh
 $ faas-cli template store pull node10-express
-```  
+```
 
 Once downloaded, your chosen template and any others stored in the same repository will be available to use:
 
@@ -79,13 +79,11 @@ The classic templates are held in the [openfaas/templates](https://github.com/op
 
 There are several Golang templates available, which are listed below.
 
-| Name | Style        | Watchdog     | Dependencies     |
-|:-----|:-------------|:-------------|:-----------------|
-| `go` | Function     | classic      | vendoring or Go modules            |
-| `golang-middleware` | Microservice     | of-watchdog      | vendoring or Go modules
-| of-watchdog      |            |
-| `golang-http` | Function     | of-watchdog      | vendoring or Go modules
-| of-watchdog      |            |
+| Name                | Style        | Watchdog    | Dependencies            |
+|:--------------------|:-------------|:------------|:------------------------|
+| `go`                | Function     | classic     | vendoring or Go modules |
+| `golang-middleware` | Microservice | of-watchdog | vendoring or Go modules |
+| `golang-http`       | Function     | of-watchdog | vendoring or Go modules |
 
 All templates are available via `faas-cli template store list/pull`
 
@@ -128,8 +126,6 @@ You can now edit `handler.go` and use the `faas-cli` to `build` and `deploy` you
 
 Dependencies should be managed with a Go modules. Vendoring is also supported.
 
-With Go modules:
-
 Set the following `build_arg` in your stack.yml file, or use `faas-cli build/up --build-arg GO111MODULE=on`.
 
 ```yaml
@@ -141,7 +137,11 @@ functions:
       GO111MODULE: on
 ```
 
-If you would like to include sub-modules, you can create a GO_REPLACE.txt file and populate it with the contents of your go.mod. A replace statement is required for use with the classic Go template.
+Now use `go mod init function` to initialize your function. Once initialized, you can now use  `go get` to manage your dependencies.
+
+###### Including sub-mobuldes
+
+If you would like to include sub-modules, a certain replace statement is required in your `go.mod` file: `replace handler/function => ./`. This replace statement allows Go to see and use all sub-modules you create with-in your handler, for example
 
 
 Create your sub-package i.e. `handlers` and run `cd handlers ; go mod init`
@@ -179,7 +179,7 @@ package function
 import (
 	"fmt"
 
-	"github.com/alexellis/with-modules/handlers"
+	"handler/function/handlers"
 )
 
 // Handle a serverless request
@@ -191,39 +191,29 @@ func Handle(req []byte) string {
 }
 ```
 
-GO_REPLACE.txt:
+Now add the following replace statement to your `go.mod`
 
 ```
-replace github.com/alexellis/with-modules/handlers => ./function/handlers
+replace handler/function => ./
+```
+
+This can also be affected using
+
+```sh
+go mod edit -replace handler/function=./
 ```
 
 Now you can build with `--build-arg GO111MODULE=on` or with a `build_arg` map entry for the function in its stack.yml.
 
-With `dep`:
 
-* Get [dep](https://github.com/golang/dep)
+###### With vendoring
 
-```
-$ go get -u github.com/golang/dep/cmd/dep
-```
-
-* Initialise the dependencies
-
-```
-$ $GOPATH/bin/dep init
-```
+You can also use vendoring with Go modules. This can reduce build times, help deal with private module dependencies, or help with ensuring reproducible builds.
 
 * Now vendor a library
 
-Make sure you're in the `go-fn` folder, now use `dep ensure -add` and the name of the library you want. In this example we are vendoring the `github.com/cnf/structhash` package for use in our function.
+Go supports vendoring using `go mod vendor`. Make sure you're in the `go-fn` folder, now use `go mod vendor` to create (or later update) your vendor folder. Go will now use this vendor folder while building your function.
 
-```
-$ dep ensure -add github.com/cnf/structhash
-```
-
-* Reference the package from function
-
-You can now edit your function and add an import statement in `handler.go` to `github.com/cnf/structhash`.
 
 ##### Go `go` - with CGO
 
@@ -303,12 +293,12 @@ Successfully installed numpy-1.14.2
 
 There are three Node.js templates which use the newer of-watchdog:
 
-| Name | Style | Runtime | Version | async/await | Supported by nodejs.org |
-|:-----|:--------|:--------|:--------|:--------------|:------------------------|
-| node8-express            | Function | NodeJS | 8.x | no      | no                      |
-| node10-express           | Function | NodeJS | 10.x | no      | no                      |
-| node10-express-service   | Micro-service | NodeJS | 10.x | no      | no                      |
-| node12                   | Function | NodeJS | 12.x | yes     | yes, LTS version        |
+| Name                   | Style         | Runtime | Version | async/await | Supported by nodejs.org |
+|:-----------------------|:--------------|:--------|:--------|:------------|:------------------------|
+| node8-express          | Function      | NodeJS  | 8.x     | no          | no                      |
+| node10-express         | Function      | NodeJS  | 10.x    | no          | no                      |
+| node10-express-service | Micro-service | NodeJS  | 10.x    | no          | no                      |
+| node12                 | Function      | NodeJS  | 12.x    | yes         | yes, LTS version        |
 
 It is recommended that all new users opt for the `node12` template.
 


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Replaces references to `dep` with using `go mod vendor` to vendor
dependencies in the Go templates.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #269 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using docker locally to preview the changes

```sh
docker run --rm -it -p 8000:8000 -v (pwd):/docs squidfunk/mkdocs-material
```
Then open http://0.0.0.0:8000/cli/templates/

![image](https://user-images.githubusercontent.com/891889/134042913-6859a787-8c89-476a-b224-9d2a692ae548.png)

You should see an updated side nav with sections for modules and vendoring

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
