### PR TITLE
Fix openfaas-ingress command example in sso page

### DIFF
--- a/docs/openfaas-pro/sso.md
+++ b/docs/openfaas-pro/sso.md
@@ -67,7 +67,7 @@ You can use the `openfaas-ingress` arkade app, or create an Ingress record manua
 ```bash
   arkade install openfaas-ingress \
   --domain gw.oauth.example \
-  --oauth2-plugin-domain auth.oauth.example \
+  --oidc-plugin-domain auth.oauth.example \
   --email webmaster@example.com
 ```
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`arkade install openfaas-ingress` example uses wrong flag `--oauth2-plugin-domain`, should be `--oidc-plugin-domain`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
