### PR TITLE
Add note on ackWait value

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -113,6 +113,12 @@ Common issues:
 * You are trying to access the gateway from your function, you must use the string `http://gateway.openfaas:8080`, otherwise it will be unreachable to you.
 * Your cloud LoadBalancer may have a timeout set of 60 seconds, which could prevent your call from executing successfully, consider increasing the timeout if you can, or execute the function asynchronously.
 
+### The queue-worker keeps retrying my function
+
+If the queue-worker keeps retrying your function check if `ack_wait` is set to a high enough timeout. It should be set to a value higher than your functions timeout.
+
+See [Expanded timeouts](https://docs.openfaas.com/tutorials/expanded-timeouts/)
+
 ### My function gets a nil or empty body
 
 If the body of the HTTP request is empty, the chances are that you are not setting a "Content-type" header in your request to the function.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a note to the troubleshooting page informing users to correctly set `ack_wait` on the queue-worker.

Based upon an issue a customer was having where the queue-worker kept
retrying messages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
