### PR TITLE
Fix wrong json field name in pro-builder docs output example

### DIFF
--- a/docs/openfaas-pro/builder.md
+++ b/docs/openfaas-pro/builder.md
@@ -117,7 +117,7 @@ curl -H "X-Build-Signature: sha256=$HMAC" -s http://127.0.0.1:8081/build -X POST
 ....
     "v: 2021-10-20T16:48:34Z exporting to image 8.01s"
   ],
-  "imageName": "docker.io/alexellis2/test-image-hello:0.1.0",
+  "image": "docker.io/alexellis2/test-image-hello:0.1.0",
   "status": "success"
 }
 ```


### PR DESCRIPTION
Signed-off-by: Han Verstraete <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix wrong json field name in output example. Change `imageName` to `image`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Different names in examples compared to the actual output can be confusing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
