### PR TITLE
Rename MAX_RAW_BODY to MAX_RAW_SIZE

### DIFF
--- a/docs/cli/templates.md
+++ b/docs/cli/templates.md
@@ -422,12 +422,12 @@ This is useful where the original body needs to be passed to the function code w
     RAW_BODY: true
 ```
 
-The raw body has a default maximum of 100KB to prevent abuse from users. This can be configured manually to deal with larger payloads:
+The raw body has a default maximum size of 100KB to prevent abuse from users. This can be configured manually to deal with larger payloads:
 
 ```yaml
   environment:
     RAW_BODY: true
-    MAX_RAW_BODY: 512kb
+    MAX_RAW_SIZE: 512kb
 ```
 
 ##### Node.js templates - Set max json request body size


### PR DESCRIPTION
Signed-off-by: Max Schmidt <ma.schmidt@reply.de>

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change renames MAX_RAW_BODY in the templates doc to MAX_RAW_SIZE for NodeJS. MAX_RAW_BODY is not used (anymore?) 

## Motivation and Context
When I tried raising the MAX_RAW_BODY to a value greater than 100kb, the change was not picked up. I wondered why and had a look into the index.js file in the build folder of the function and the important part is:
`const rawLimit = process.env.MAX_RAW_SIZE || defaultMaxSize`
As you can see, MAX_RAW_BODY is not the correct variable and thus wrong in the documentation.


## How Has This Been Tested?
When I tried raising the MAX_RAW_BODY to a value greater than 100kb, the change was not picked up. I then changed the variable to MAX_RAW_SIZE and it worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
- [ X ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ X ] I have signed-off my commits with `git commit -s`
