### PR TITLE
Add note on callback for retries

### DIFF
--- a/docs/openfaas-pro/retries.md
+++ b/docs/openfaas-pro/retries.md
@@ -95,6 +95,8 @@ The invocation will fail, returning a 429 message. This will be received by the 
 
 Allow it to fail several times, seeing the retry time back off exponentially.
 
+> For undelivered messages that reach maximum retries the response is posted to the [callback url](https://docs.openfaas.com/reference/async/#how-it-works). 
+
 Then, whenever you like, fix the error by changing the canned HTTP response to "200 OK". This will allow the next retry to complete:
 
 ```bash


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a note in the retries documentation to inform users about the new behaviour for undelivered messages that reach maximum retries.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Documentation update for changes made in:
- https://github.com/openfaasltd/nats-queue-worker/pull/5
- https://github.com/openfaasltd/jetstream-queue-worker/pull/9

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
