### PR TITLE
Document readiness path annotation

### DIFF
--- a/docs/reference/workloads.md
+++ b/docs/reference/workloads.md
@@ -203,6 +203,10 @@ functions:
       com.openfaas.health.http.periodSeconds: 5s
 ``` 
 
-> Note: The initial delay value must be a valid Go duration e.g. `80s` or `3m`. 
+> Note: The initial delay value must be a valid Go duration e.g. `80s` or `3m`.
+
+Readiness probes use the same HTTP path as the health check by default. A custom ready path can be set with the following annotation:
+
+* `com.openfaas.ready.http.path`
 
 The `timeoutSeconds` value for liveness and readiness probes can be set globally for the installation: [OpenFaaS chart reference](https://github.com/openfaas/faas-netes/tree/master/chart/openfaas#faas-netes--operator). A global `initialDelaySeconds` and `periodSeconds` can also be set for the installation, any overrides set for these two values in annotations will take precedence.


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Document the readiness annotation in the workload reference.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

No documentation for custom readiness path.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran docs site locally to verify.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
