### PR TITLE
Add example of pro plugin with private npm modules

### DIFF
--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -37,7 +37,7 @@ Below we have an example for Python using the pip package manager and for node m
 1. Download and enable the OpenFaaS Pro plugin
 2. Create a local file in the format required
 3. Update a `build_secret` in `stack.yml` so it gets mounted into the container
-4. Run `faas-cli build` or `faas-cli publish`, `faas-cli up` is not available at this time
+4. Run `faas-cli pro build` or `faas-cli pro publish`, `faas-cli pro up` is not available at this time
 
 ### Private access to a Python pip repository
 
@@ -83,10 +83,10 @@ index-url = https://aws:CODEARTIFACT_TOKEN@OWNER-DOMAIN.d.codeartifact.us-east-1
 Then run a build with:
 
 ```bash
-faas-cli build
+faas-cli pro build
 ```
 
-The `faas-cli publish` command can also be used instead of `faas-cli build`.
+The `faas-cli pro publish` command can also be used instead of `faas-cli pro build`.
 
 Within a GitHub Action, the short-lived token associated to the job is used to verify your license for this feature.
 
@@ -104,7 +104,7 @@ Then:
 faas-cli plugin get pro
 faas-cli pro enable
 
-faas-cli build / publish
+faas-cli pro build / publish
 ```
 
 You'll also need to update the Python template to mount the secret passed in from the OpenFaaS Pro plugin:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add build example for private npm modules.
- Fix the commands in the python example. They used `faas-cli <command>` instead of `faas-cli pro <command>`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Add example for building functions using private npm modules.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested all instructions and verified changes to the docs visually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
