### PR TITLE
Fix numbering and connector name in postgres-connector page

### DIFF
--- a/docs/openfaas-pro/postgres-events.md
+++ b/docs/openfaas-pro/postgres-events.md
@@ -8,8 +8,8 @@ Trigger functions from [PostgreSQL](https://www.postgresql.org/) tables efficien
 
 There are two options for triggering functions from Postgres:
 
-1) Using logical replication and the Write Ahead Log (WAL) (explained here)
-2) Using LISTEN/NOTIFY and a series of table-level triggers (contact us for instructions)
+1. Using logical replication and the Write Ahead Log (WAL) (explained here)
+2. Using LISTEN/NOTIFY and a series of table-level triggers (contact us for instructions)
 
 ### Configure your Postgresql database
 
@@ -45,7 +45,7 @@ PGPASSWORD=passwd psql -U postgres -h 127.0.0.1
 
 * Set up the connector
 
-    You can install the SQS connector using its [helm chart](https://github.com/openfaas/faas-netes/tree/master/chart/postgres-connector).
+    You can install the Postgres connector using its [helm chart](https://github.com/openfaas/faas-netes/tree/master/chart/postgres-connector).
 
     The values.yaml file can be customised to suit your needs.
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix the numbering and a wrong reference to the SQS connector in the docs for the postgres-connector.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix docs formatting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran docs site locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
