### PR TITLE
Add new probing annotations to workloads page

### DIFF
--- a/docs/reference/workloads.md
+++ b/docs/reference/workloads.md
@@ -186,21 +186,25 @@ On Kubernetes is possible to run any container image as an OpenFaaS function as 
 !!! info "OpenFaaS Pro feature"
     This feature is part of the [OpenFaaS Pro](/openfaas-pro/introduction) distribution.
 
-The `timeoutSeconds`, `initialDelaySeconds` and `periodSeconds` for liveness and readiness probes can be set globally for the installation: [OpenFaaS chart reference](https://github.com/openfaas/faas-netes/tree/master/chart/openfaas#faas-netes--operator).
+Liveness and readiness probes can be set globally for the installation: [OpenFaaS chart reference](https://github.com/openfaas/faas-netes/tree/master/chart/openfaas#faas-netes--operator).
 
 Annotations can be used to configure probes on a per function basis. Any overrides set in annotations will take precedence over the global configuration.
 
-You can specify the HTTP path of your health check and the initial check delay duration with the following annotations:
+You can specify the HTTP path of your health check and control the behavior of the probe with the following annotations:
 
 * `com.openfaas.health.http.path`
-* `com.openfaas.health.http.initialDelay`
+* `com.openfaas.health.http.initialDelaySeconds`
 * `com.openfaas.health.http.periodSeconds`
+* `com.openfaas.health.http.timeoutSeconds`
+* `com.openfaas.health.http.failureThreshold`
 
-Readiness probes use the same HTTP path as the health check by default. The path, initial check delay and failure threshold can be set with these annotations:
+Readiness probes use the same HTTP path as the health check by default. The path, and other probing fields can be configured with these annotations:
 
 * `com.openfaas.ready.http.path`
-* `com.openfaas.ready.http.initialDelay`
+* `com.openfaas.ready.http.initialDelaySeconds`
 * `com.openfaas.ready.http.periodSeconds`
+* `com.openfaas.ready.http.timeoutSeconds`
+* `com.openfaas.ready.http.successThreshold`
 * `com.openfaas.ready.http.failureThreshold`
 
 
@@ -213,11 +217,9 @@ functions:
     skip_build: true
     annotations:
       com.openfaas.ready.http.path: "/_/ready"
-      com.openfaas.ready.http.initialDelay: "30s"
-      com.openfaas.ready.http.periodSeconds: 5s
-``` 
-
-> Note: The initial delay value must be a valid Go duration e.g. `80s` or `3m`.
+      com.openfaas.ready.http.initialDelaySeconds: 30
+      com.openfaas.ready.http.periodSeconds: 5
+```
 
 ### Function information
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add new probing annotations to the workloads page.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Document the additional liveness and readiness probing annotations that where added to OpenFaaS Pro.

Requested in: https://github.com/openfaas/faas-netes/issues/1042

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
