### PR TITLE
Use new API group in IAM object examples

### DIFF
--- a/docs/openfaas-pro/iam/example-auth0.md
+++ b/docs/openfaas-pro/iam/example-auth0.md
@@ -9,7 +9,7 @@ Create an application on Auth0 for the OpenFaaS gateway, you'll need to obtain t
 An Issuer for `https://alexellis.eu.auth0.com/` might look like this:
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: JwtIssuer
 metadata:
   name: alexellis.eu.auth0.com
@@ -27,7 +27,7 @@ spec:
 Once registered, a Role must be created which maps users within the Issuer to be mapped to a set of Policies
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: Role
 metadata:
   name: dev-staff-deployers
@@ -67,7 +67,7 @@ A user's email could also be fuzzy matched with a condition, for example:
 Finally, one or more Policies must be created which describe which permissions a user has, and on which resources.
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: Policy
 metadata:
   name: dev-rw
@@ -86,7 +86,7 @@ spec:
 > Allow read and write to functions and secrets within the `dev` namespace:
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: Policy
 metadata:
   name: staging-readonly

--- a/docs/openfaas-pro/iam/github-actions-federation.md
+++ b/docs/openfaas-pro/iam/github-actions-federation.md
@@ -11,7 +11,7 @@ Your build will need to be adapted in order to receive an id_token from GitLab, 
 First define a new JwtIssuer resource, setting the `aud` field to the URL of your OpenFaaS Gateway.
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: JwtIssuer
 metadata:
   name: token.actions.githubusercontent.com
@@ -30,7 +30,7 @@ spec:
 Next, define a Policy with the least privileges required to perform the desired actions.
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: Policy
 metadata:
   name: dev-rw
@@ -81,7 +81,7 @@ There are around a dozen different fields available within the GitHub Actions `i
 > Example from: [Deploy without credentials with GitHub Actions and OIDC](https://blog.alexellis.io/deploy-without-credentials-using-oidc-and-github-actions/)
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: Role
 metadata:
   name: dev-actions-deployer

--- a/docs/openfaas-pro/iam/gitlab-federation.md
+++ b/docs/openfaas-pro/iam/gitlab-federation.md
@@ -11,7 +11,7 @@ Your build will need to be adapted in order to receive an id_token from GitLab, 
 First define a new JwtIssuer resource, setting the `aud` field to the URL of your OpenFaaS Gateway.
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: JwtIssuer
 metadata:
   name: gitlab.com
@@ -30,7 +30,7 @@ spec:
 Next, define a Policy with the least privileges required to perform the desired actions.
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: Policy
 metadata:
   name: dev-rw
@@ -53,7 +53,7 @@ Next, you need to bind the Policy to a Role.
 There are around a dozen different fields available within GitLab's `id_token`, you can view a complete list at: [GitLab OIDC: Shared information](https://docs.gitlab.com/ee/integration/openid_connect_provider.html#shared-information)
 
 ```yaml
-apiVersion: openfaas.com/v1
+apiVersion: iam.openfaas.com/v1
 kind: Role
 metadata:
   name: gitlab-dev-actions-deployer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Use new API group in IAM object examples

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

The IAM objects have been moved to a separate API group: `iam.openfaas.com/v1`. Update the docs to reflect this change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
