### PR TITLE
Fixes #348: CE Install docs incorrectly say Function CRD is installed

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -157,7 +157,7 @@ See also:
 * [OpenFaaS and Flux v2](https://www.openfaas.com/blog/upgrade-to-fluxv2-openfaas/)
 * [OpenFaaS and Flux v1](https://www.openfaas.com/blog/openfaas-flux/)
 
-OpenFaaS also ships with a Function Custom Resource Definition which is required for use with GitOps tooling or to package functions with Helm.
+With an OpenFaaS Pro License, it also ships with a Function Custom Resource Definition which is required for use with GitOps tooling or to package functions with Helm.
 
 See also: [Learn how to manage your functions with kubectl](https://www.openfaas.com/blog/manage-functions-with-kubectl/)
 


### PR DESCRIPTION
## Description
Update the docs to say you need a pro license or remove that section of the docs.

## Motivation and Context
Found this while trying to deploy a new instance of OpenFaaS CE, but the Function CRDs were not installed.

Issue: #348 
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Not test, as it is only a text change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
