### PR TITLE
Add gateway flag in faas-cli pro auth examples

### DIFF
--- a/docs/openfaas-pro/iam/example-auth0.md
+++ b/docs/openfaas-pro/iam/example-auth0.md
@@ -119,6 +119,7 @@ The `faas-cli` needs to be used to obtain a token from Auth0, and then exchange 
 
 ```bash
 faas-cli pro auth \
+  --gateway https://gateway.example.com \
   --grant code \
   --authority https://example.eu.auth0/ \
   --client-id 17F3M3rS8ORQUPDHsgkq0YVHheZVH8dpaGHRTjAx5x0

--- a/docs/openfaas-pro/iam/overview.md
+++ b/docs/openfaas-pro/iam/overview.md
@@ -120,6 +120,7 @@ To print out the decoded OpenFaaS JWT token run:
 
 ```sh
 faas-cli pro auth \
+  --gateway https://gateway.example.com \
   --authority https://keycloak.example.com/realms/openfaas \
   --client-id openfaas \
   --pretty


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add the gateway flag in `faas-cli pro auth` examples.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Explicitly show users that they need to run the pro auth commands against the correct gateway.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
