### PR TITLE
Document support for the strategy field in profiles

### DIFF
--- a/docs/openfaas-pro/introduction.md
+++ b/docs/openfaas-pro/introduction.md
@@ -209,6 +209,7 @@ Scaling to zero is also a commercial feature, which can be opted into on a per f
 | Custom runtimeClassName    | n/a        | n/a | As per Standard |
 | Custom topologySpreadConstraints    | n/a        | Supported via Profiles | As per Standard |
 | Custom affinity/anti-affinity    | n/a        | Supported via Profiles | As per Standard |
+| Custom deployment strategy | n/a | Supported via Profiles | As per Standard |
 | Additional resources (e.g device plugin managed resources) | n/a | Supported via Profiles | As per standard |
 | nodeSelector | n/a | Available via `constraints` in Function spec | As per Standard |
 | Custom DNS configuration | n/a | Supported via Profiles | As per Standard |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Update the documentation to mention the strategy field that is now available in the Profile CR.
- Show how the `Recreate` strategy type can be used for scheduling functions that require GPU.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Keep the profiles documentation up to date for latest features and show user how to use the strategy with GPU functions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified any new `yaml` examples and instructions are valid.
- Verified the docs render correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
