### PR TITLE
Add note on using profiles to set default CPU/RAM

### DIFF
--- a/docs/reference/profiles.md
+++ b/docs/reference/profiles.md
@@ -71,6 +71,9 @@ Profiles in Kubernetes work by injecting the supplied configuration directly int
 
 The configuration use the exact options that you find in the Kubernetes documentation.
 
+!!! note "Configuration priority"
+    Resources set in the function spec take precedence over resources set through Profiles.
+
 ### Examples
 
 #### Use an Alternative RuntimeClass
@@ -429,3 +432,33 @@ spec:
     limits:
       nvidia.com/gpu: 1 # requesting 1 GPU
 ```
+
+#### Set default RAM/CPU for all functions
+
+You might want to set default memory and CPU resources for all your functions. This can be done by creating a Profile and applying it to all your functions by default.
+
+Example of a profile that sets Memory/CPU limits and requests:
+
+```yaml
+kind: Profile
+apiVersion: openfaas.com/v1
+metadata:
+    name: default-resources
+    namespace: openfaas
+spec:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "250m"
+    limits:
+      memory: "128Mi"
+      cpu: "500m"
+```
+
+Add the profiles annotation to all functions to apply this profile.
+
+```yaml
+com.openfaas.profile: default-resources
+```
+
+It is still possible to override the default settings on a per function basis by setting different values in the function `stack.yaml`: see [Memory/CPU limits](/reference/yaml/#function-memorycpu-limits). Resources set in the function spec take precedence over resources set through Profiles.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Add a note for configuration priority of resources set through profiles.
- Add an example section to show how profiles can be used to set default RAM/CPU for all functions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

- Add documentation for recent changes in configuration priority for profiles.
- Improve the profiles examples.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified the docs site renders correctly.
- Verified all links are working
- Verified new code samples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
