### PR TITLE
Fix indentation in function auth yaml example

### DIFF
--- a/docs/openfaas-pro/iam/function-authentication.md
+++ b/docs/openfaas-pro/iam/function-authentication.md
@@ -19,9 +19,9 @@ Authentication can be enabled on a per function basis by setting the `jwt_auth` 
 functions:
   figlet:
     skip_build: true
-      image: ghcr.io/openfaas/figlet:latest
-      environment:
-        jwt_auth: true
+    image: ghcr.io/openfaas/figlet:latest
+    environment:
+      jwt_auth: true
 ```
 
 !!! note


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix the indentation in function configuration yaml example.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fix function authentication example.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the yaml indentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
