### PR TITLE
Fix languages links on overview page

### DIFF
--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -12,23 +12,23 @@ There are many community templates, of varying levels of support and maintenance
 
 There are a number of official templates maintained and recommended by OpenFaaS Ltd, the following are currently documented:
 
-* [Go](/languages/go)
-* [Node](/languages/go)
-* [Python](/languages/go)
-* [Dockerfile](/languages/dockerfile)
-* [CSharp](/languages/csharp)
+* [Go](./go.md)
+* [Node](./node.md)
+* [Python](./python.md)
+* [Dockerfile](./dockerfile.md)
+* [CSharp](./csharp.md)
 
 See also: [other templates information - C#, Java, Ruby, Rust and Bash](/cli/templates)
 
 Community support:
 
-* [PHP](/languages/php)
+* [PHP](./php.md)
 
 Additional templates are available from the community via `faas-cli template store list`
 
 ### Custom templates
 
-You can also [create your own custom templates](/languages/custom), or fork an existing template and adapt it for your own needs.
+You can also [create your own custom templates](./custom.md), or fork an existing template and adapt it for your own needs.
 
 ### Existing Dockerfiles / images
 


### PR DESCRIPTION


## Description

This also moves to relative URLs, which can be checked by `mkdocs`.

## Motivation and Context

Links were previously wrong and always went to the Go docs.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
