### PR TITLE
Remove function name from async cancel examples

### DIFF
--- a/docs/reference/async.md
+++ b/docs/reference/async.md
@@ -73,12 +73,12 @@ Alternatively you can specify another asynchronous or synchronous function to ru
 
 ### Cancel async invocations
 
-Sometimes you might need to cancel an ongoing or queued invocation. Asynchronous invocations can be cancelled by making an HTTP `DELETE` request to `/async-function/<name>/<call-id>`. The call id is the X-Call-Id header that was returned when submitting the async invocation.
+Sometimes you might need to cancel an ongoing or queued invocation. Asynchronous invocations can be cancelled by making an HTTP `DELETE` request to `/async-function/<call-id>`. The call id is the X-Call-Id header that was returned when submitting the async invocation.
 
 ```bash
 $ curl -i \
   -X DELETE \
-  http://127.0.0.1:8080/async-function/sleep/ee7fcaeb-82b7-4834-b677-45005c5f0b1b
+  http://127.0.0.1:8080/async-function/ee7fcaeb-82b7-4834-b677-45005c5f0b1b
 ```
 
 A `202 Accepted` message will be issued if the request is successful.

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -134,12 +134,12 @@ You can expose Functions with a REST-like mapping or on custom subdomains with t
 
 ### Cancel an async invocation
 
-To cancel an asynchronous function invocation an HTTP `DELETE` request can be made to the async function endpoint with the call id of the invocation that needs to be cancelled as a path parameter: `/async-function/<name>.<namespace>/<call-id>`
+To cancel an asynchronous function invocation an HTTP `DELETE` request can be made to the async function endpoint with the call id of the invocation that needs to be cancelled as a path parameter: `/async-function/<call-id>`
 
 ```bash
 curl -i \
   -X DELETE \
-  http://127.0.0.1:8080/async-function/sleep/ee7fcaeb-82b7-4834-b677-45005c5f0b1b
+  http://127.0.0.1:8080/async-function/ee7fcaeb-82b7-4834-b677-45005c5f0b1b
 ```
 
 A `202 Accepted` message will be issued if the request is successful.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove function name path parameter from async cancel examples.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

The endpoint was updated to only take the call id as a path parameter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
