### PR TITLE
Add docs for using gVisor with OpenFaaS Edge

### DIFF
--- a/docs/edge/gvisor.md
+++ b/docs/edge/gvisor.md
@@ -1,0 +1,33 @@
+# gVisor runtime
+
+Improve container security with [gVisor](https://gvisor.dev/). The gVisor runsc runtime improves isolation between the Linux host and function containers so you can safely run untrusted code e.g. user-uploaded, LLM-generated, or third-party code. 
+
+OpenFaaS Edge supports using the gVisor runsc runtime for functions.
+If you are using OpenFaaS Pro on Kubernetes the runtime is supported via [Profiles](/reference/profiles/#use-an-alternative-runtimeclass). 
+
+## Installation
+
+To start using gVisor with OpenFaaS Edge install runsc and the containerd runsc shim using the [gVisor installation docs](https://gvisor.dev/docs/user_guide/install/).
+
+> Note: The containerd configuration does not need to be updated to use gVisor with OpenFaaS Edge.
+
+### New OpenFaaS Edge installation
+
+[Follow the installation instructions](/deployment/edge/#openfaas-edgefaasd-pro-commercial-use) to install OpenFaaS Edge. When you reach the step to run the `faasd install` command make sure to add the `--gvisor` flag:
+
+```sh
+faasd install --gvisor
+```
+
+### Change the runtime for an existing installation
+
+When you want to change the runtime for an existing OpenFaaS Edge deployment run:
+
+```sh
+faasd install --gvisor
+
+systemctl daemon-reload
+systemctl restart faasd-provider
+```
+
+Make sure to redeploy functions to switch them over to the new runtime.

--- a/docs/edge/overview.md
+++ b/docs/edge/overview.md
@@ -13,6 +13,7 @@ Most of the [OpenFaaS Pro documentation](/docs/openfaas-pro/) and [Helm charts](
 * [Custom DNS servers](/edge/custom-dns)
 * [Kafka Connector for OpenFaaS Edge](/edge/kafka-deployment)
 * [GPU support for services](/edge/gpus)
+* [Improve container security with gVisor](/edge/gvisor)
 
 ## Looking for something else?
 

--- a/docs/edge/scale-to-zero.md
+++ b/docs/edge/scale-to-zero.md
@@ -21,3 +21,28 @@ The global idle period can be adjusted by editing the `faas-idler` section of `/
       - "write_debug=false"
 ```
 
+## Scaling up from zero
+
+Functions are automatically scaled up from zero when there is a request. By default the OpenFaaS gateway probes the function ready endpoint to know if a function is ready to start accepting requests before forwarding the request.
+
+The watchdog implements the default ready endpoint `/_/ready`. You can override the endpoint by setting the annotation `com.openfaas.ready.http.path` on the function. A custom ready endpoint can be used if you have a function that is slow to start. 
+
+!!! note "Scale from zero with gVisor"
+
+    Some languages, like NodeJS, take longer to initialize when using the gVisor runsc runtime. The watchdog reports ready while the function process is still initializing. It is recommended to implement and configure a custom readiness endpoint on the function. 
+
+To extend the probing duration adjust the global probing configuration by editing the `gateway` section of `/var/lib/faasd/docker-compose.yaml`
+
+```yaml
+services:
+  gateway:
+    environment:
+      # The interval between probes
+      - probe_interval=100ms
+      # Max number of probes
+      - probe_count=20
+
+```
+
+To turn of function probing set `probe_functions=false`.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,6 +181,7 @@ nav:
       - Scale to Zero: ./edge/scale-to-zero.md
       - Kafka connector: ./edge/kafka-deployment.md
       - GPU for services: ./edge/gpus.md
+      - gVisor: ./edge/gvisor.md
   - Reference:
     - OpenFaaS YAML: ./reference/yaml.md
     - REST API: ./reference/rest-api.md


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add documentation on how to configure the gVisor `runsc` runtime as the container runtime for functions on OpenFaaS Edge.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Add documentation for gVisor support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
