### PR TITLE
Remove references to python3 template

### DIFF
--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -219,7 +219,7 @@ The OpenFaaS CLI provides a `--build-option` flag which enables named sets of na
 There are two ways to achieve this:
 
 ```bash
-faas-cli build --lang python3 --build-option dev [--build-option debug]
+faas-cli build --lang python3-http --build-option dev [--build-option debug]
 ```
 
 or in YAML:
@@ -272,13 +272,13 @@ RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
 There may be scenarios where a single native module needs to be added to a build.  A single-package build option could be added as described above.  Alternatively a package could be specified through a `--build-arg`.
 
 ```bash
-faas-cli build --lang python3 --build-arg ADDITIONAL_PACKAGE=jq
+faas-cli build --lang python3-http --build-arg ADDITIONAL_PACKAGE=jq
 ```
 
 In the event a `build-option` is set the effect will be cumulative:
 
 ```bash
-faas-cli build --lang python3 --build-option dev --build-arg ADDITIONAL_PACKAGE=jq
+faas-cli build --lang python3-http --build-option dev --build-arg ADDITIONAL_PACKAGE=jq
 ```
 
 The entries in the template's Dockerfile described in 1.0 above need to be present for this mode of operation.

--- a/docs/openfaas-pro/builder.md
+++ b/docs/openfaas-pro/builder.md
@@ -69,11 +69,11 @@ export PAYLOAD=$(kubectl get secret -n openfaas payload-secret -o jsonpath='{.da
 echo $PAYLOAD > $HOME/.openfaas/payload.txt
 ```
 
-Create a test function using the `python3` template, and set it to publish to `ttl.sh`, an ephemeral registry that doesn't require authentication:
+Create a test function using the `python3-http` template, and set it to publish to `ttl.sh`, an ephemeral registry that doesn't require authentication:
 
 ```bash
 faas-cli new --prefix ttl.sh/test-images \
-    --lang python3 py-fn
+    --lang python3-http py-fn
 ```
 
 Now, publish an image using the remote builder:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove references to python3 template which has been deprecated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
