### PR TITLE
Document NATS reconnect counter metrics

### DIFF
--- a/docs/architecture/metrics.md
+++ b/docs/architecture/metrics.md
@@ -50,6 +50,7 @@ Advanced metrics for OpenFaaS Pro users:
 | `http_request_duration_seconds`     | histogram  | Seconds spent serving HTTP requests | `method`, `path`, `status` | Pro Edition  |
 | `http_requests_total`               | counter    | The total number of HTTP requests   | `method`, `path`, `status` | Pro Edition  |
 | `http_requests_total`               | counter    | The total number of HTTP requests   | `method`, `path`, `status` | Pro Edition  |
+| `gateway_nats_reconnect_total`      | counter    | Total number of times the NATS client has reconnected |                            | Pro Edition  |
 
 The `http_request*` metrics record the latency and statistics of `/system/*` routes to monitor the OpenFaaS gateway and its provider. The `/async-function` route is also recorded in these metrics to observe asynchronous ingestion rate and latency.
 
@@ -60,6 +61,7 @@ Additional metrics from the Operator:
 | `faasnetes_scale_total`                  | counter    | Number of times a function has been scaled (ignoring requests where current and desired replicas are equal) | `function_name`, `status` | Pro Edition  |
 | `faasnetes_sync_handler_gauge`             | gauge      | Number of reconciliation functions running at given time | `status` | Pro Edition  |
 | `faasnetes_sync_handler_histogram`        | histogram  | Time taken to reconcile function Custom Resources into Kubernetes objects | `status` | Pro Edition  |
+| `faasnetes_nats_reconnect_total`          | counter    | Total number of times the NATS client has reconnected |            | Pro Edition  |
 
 The `faasnetes_scale_total` metric is useful for tracking the number of times a function has been scaled up or down. The `faasnetes_sync_handler_gauge` and `faasnetes_sync_handler_histogram` metrics are useful for tracking the amount of time spent reconciling function Custom Resources into Kubernetes objects in large deployments of OpenFaaS.
 
@@ -82,6 +84,7 @@ The queue-worker for NATS JetStream exposes metrics to help you get insight in t
 | `queue_worker_messages_processed_total` | counter    | Total number of messages processed              | `queue_name`, `kubernetes_pod_name` | Pro Edition |
 | `queue_worker_messages_submitted_total` | gauge      | Total number of messages submitted to the queue by the gateway | `queue_name`, `kubernetes_pod_name` | Pro Edition |
 | `queue_worker_function_invocation_inflight` | gauge |  Total number of inflight function requests made by the queue-worker | `queue_name`, `function_name` | Pro Edition |
+| `queue_worker_nats_reconnect_total` | counter | Total number of times the NATS client has reconnected | | Pro Edition |
 
 ## Watchdog
 


### PR DESCRIPTION
## Description
Add documentation for the new Prometheus counter metrics that track NATS client reconnections:

- `gateway_nats_reconnect_total` - Gateway
- `faasnetes_nats_reconnect_total` - Operator (faas-netes)
- `queue_worker_nats_reconnect_total` - JetStream queue-worker

## Motivation and Context
New NATS reconnect counter metrics were added across the gateway, operator and JetStream queue-worker components. The metrics documentation needs to be updated to include them.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Verified the metrics page renders correctly with mkdocs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`