### PR TITLE
Document Retry-After header support for async retries

### DIFF
--- a/docs/openfaas-pro/retries.md
+++ b/docs/openfaas-pro/retries.md
@@ -91,6 +91,19 @@ Supported backoff values:
 
 The feature was influenced by [Marc Brooker's article on Exponential Backoff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/).
 
+## Retry-After header
+
+When a function returns a `429 Too Many Requests` or `503 Service Unavailable` status code, it can include a `Retry-After` header to tell the queue-worker how long to wait before the next retry attempt. This is useful when a function or downstream API knows how long it will be rate-limited or unavailable.
+
+Both delay-seconds and HTTP-date formats are supported:
+
+```
+Retry-After: 30
+Retry-After: Fri, 10 Apr 2026 09:47:00 GMT
+```
+
+When present, the header value is used as the retry delay instead of the calculated exponential backoff. If the value is below the configured minimum retry wait (`initialRetryWait` / `com.openfaas.retry.min_wait`), the minimum is used instead. Invalid or unparseable values fall back to normal backoff.
+
 ## Usage
 
 To test the retry functionality, you can use our chaos function, which allows a function to be configured to return a canned response, or to timeout with a given duration.


### PR DESCRIPTION
## Description

Add a "Retry-After header" section to the retries documentation explaining
how functions can return a `Retry-After` header on `429` or `503` responses
to control the next retry delay in the queue-worker.

Both delay-seconds and HTTP-date formats are documented.

## Motivation and Context

The jetstream queue-worker now supports the `Retry-After` response header
on both `429 Too Many Requests` and `503 Service Unavailable` responses.
This documents the feature for users.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`