### PR TITLE
Fix broken link to Python language page in overview

### DIFF
--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -14,7 +14,7 @@ There are a number of official templates maintained and recommended by OpenFaaS 
 
 * [Go](./go.md)
 * [Node](./node.md)
-* [Python](./python.md)
+* [Python](./python/index.md)
 * [Dockerfile](./dockerfile.md)
 * [CSharp](./csharp.md)
 


### PR DESCRIPTION
## Description
Updates the link to the Python language page in `docs/languages/overview.md` from `./python.md` to `./python/index.md` to match the current location of the Python docs.

## Motivation and Context
The Netlify build is failing in strict mode because of a broken link:

```
WARNING - Doc file 'languages/overview.md' contains a link './python.md',
but the target 'languages/python.md' is not found among documentation files.
Aborted with 1 warnings in strict mode!
```

The Python documentation lives at `languages/python/index.md` (as referenced in `mkdocs.yml`), so the overview link needed to be updated to match.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Verified the link target exists at `docs/languages/python/index.md`. The fix removes the only WARNING that was causing `mkdocs build --strict` to abort in the Netlify deploy preview.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
