### PR TITLE
Document custom readiness endpoint for scale from zero

### DIFF
--- a/docs/architecture/autoscaling.md
+++ b/docs/architecture/autoscaling.md
@@ -373,6 +373,16 @@ The latency between accepting a request for an unavailable function and serving 
 
     For an overview of cold-starts in OpenFaaS see: [Dude where's my coldstart?](https://www.openfaas.com/blog/what-serverless-coldstart/)
 
+* What if my function takes time to start?
+
+    The OpenFaaS watchdog provides a built-in readiness check by default. Some workloads aren't ready as soon as the process starts, so scale from zero may require a custom readiness endpoint to let the gateway know when it's fully ready before sending traffic to the function. This is especially important if your function takes some time to start, for example to:
+
+    * Establish a connection pool to a database or message broker
+    * Load a large machine-learning model or dataset into memory
+    * Warm an in-memory cache before serving requests
+
+    In this case you can configure a custom readiness endpoint with the `com.openfaas.ready.http.*` annotations on your function, see: [Workloads: custom HTTP health checks](/reference/workloads#custom-http-health-checks). Read more on the blog: [Custom health and readiness checks for your functions](https://www.openfaas.com/blog/health-and-readiness-for-functions/).
+
 * What if my function is still running when it gets scaled down?
 
     That shouldn't happen, providing that you've set an adequate value for the idle detection for your function. But if it does, the OpenFaaS watchdog and our official function templates will allow a graceful termination of the function. See also: [Improving long-running jobs for OpenFaaS users](https://www.openfaas.com/blog/long-running-jobs/)

--- a/docs/openfaas-pro/scale-to-zero.md
+++ b/docs/openfaas-pro/scale-to-zero.md
@@ -132,6 +132,14 @@ The time taken to scale up a function and have it ready to serve traffic is call
 
 Cold-starts can be tuned through the OpenFaaS Helm chart: [Tuning function cold-starts](https://github.com/openfaas/faas-netes/tree/master/chart/openfaas#tuning-function-cold-starts)
 
+The OpenFaaS watchdog provides a built-in readiness check by default. Some workloads aren't ready as soon as the process starts, so scale from zero may require a custom readiness endpoint to let the gateway know when a function is ready to receive traffic. This is especially important if your function takes some time to start, for example to:
+
+* Establish a connection pool to a database or message broker
+* Load a large machine-learning model or dataset into memory
+* Warm an in-memory cache before serving requests
+
+Configure a readiness endpoint with the `com.openfaas.ready.http.*` annotations on your function, see: [Workloads: custom HTTP health checks](/reference/workloads#custom-http-health-checks). Read more on the blog: [Custom health and readiness checks for your functions](https://www.openfaas.com/blog/health-and-readiness-for-functions/).
+
 ## Would you like a demo?
 
 Feel free to reach out to us for a demo or to ask any questions you may have.


### PR DESCRIPTION
## Description
Note on the Scale to Zero and Auto-scaling pages that some workloads may
need a custom readiness endpoint when scaling from zero.

## Motivation and Context
Slow-starting functions may need a custom readiness endpoint so the
gateway only sends traffic once the function is fully ready. This wasn't
mentioned in the docs.
- [ ] I have raised an issue to propose this change (required)

## How Has This Been Tested?
Checked the rendered Markdown and verified links.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with `git commit -s`