### PR TITLE
Add a Python readiness-check example

### DIFF
--- a/docs/languages/python/examples/readiness.md
+++ b/docs/languages/python/examples/readiness.md
@@ -12,7 +12,7 @@ Use-cases:
 !!! info "OpenFaaS Pro feature"
     Custom readiness checks are configured with the `com.openfaas.ready.http.*` annotations, which are part of the [OpenFaaS Pro](/openfaas-pro/introduction) distribution. On Community Edition the readiness probe always uses `/_/health` and these annotations are ignored.
 
-## Handler
+## Overview
 
 Run the slow initialisation off the request path — in a background thread started at module load — and set a flag when it finishes. The handler returns `200` from `/ready` once the flag is set, and `503` while it is still initialising.
 
@@ -48,16 +48,25 @@ def handle(event, context):
 
 The flag is a plain boolean, which is safe here: the background thread only ever sets it to `True`, and the handler only reads it.
 
-## stack.yaml
+## Scaffold the function
 
-Point the readiness probe at the `/ready` path with an annotation:
+Pull the template and scaffold a new function:
+
+```bash
+faas-cli template store pull python3-http
+faas-cli new --lang python3-http ready-example \
+  --prefix ttl.sh/openfaas-examples
+```
+
+The example uses the public [ttl.sh](https://ttl.sh) registry — replace the prefix with your own registry for production use.
+
+Update `ready-example/handler.py` with the code from the overview above.
+
+## Configure the readiness probe
+
+Point the readiness probe at the `/ready` path by adding these annotations to the function in `ready-example.yml`:
 
 ```yaml
-functions:
-  ready-example:
-    lang: python3-http
-    handler: ./ready-example
-    image: ${REGISTRY}/ready-example:latest
     annotations:
       com.openfaas.ready.http.path: /ready
       com.openfaas.ready.http.initialDelaySeconds: 2
@@ -77,17 +86,21 @@ The full set of probe annotations (`timeoutSeconds`, `successThreshold`, `failur
 
 ## Deploy and verify
 
+Build, push and deploy the function with `faas-cli up`:
+
 ```bash
-faas-cli up
+faas-cli up \
+ --filter ready-example \
+ --tag digest
 ```
 
-Confirm the function reports `Ready` before treating it as available:
+The function reports `Not Ready` until `initialize()` finishes, then `Ready`. Confirm before treating it as available:
 
 ```bash
 faas-cli describe ready-example
 ```
 
-To see the check working, scale to zero and invoke it — the first request must succeed rather than return a 500:
+Because the readiness probe holds traffic back until then, the first request to any freshly started Pod — after a cold start, a rolling update, or a scale-from-zero — succeeds rather than returning a 500:
 
 ```bash
 curl https://$OPENFAAS_URL/function/ready-example

--- a/docs/languages/python/examples/readiness.md
+++ b/docs/languages/python/examples/readiness.md
@@ -11,8 +11,8 @@ Use-cases:
 * Opening a database or SDK connection pool
 * Downloading reference data before the first request
 
-!!! info "OpenFaaS Pro feature"
-    Custom readiness checks are configured with the `com.openfaas.ready.http.*` annotations, which are part of the [OpenFaaS Pro](/openfaas-pro/introduction) distribution. On Community Edition the readiness probe always uses `/_/health` and these annotations are ignored.
+!!! info "OpenFaaS Pro"
+    Wiring the Kubernetes readiness probe to a custom path with the `com.openfaas.ready.http.*` annotations is part of [OpenFaaS Pro](/openfaas-pro/introduction). The `/ready` endpoint itself is ordinary handler code and runs anywhere.
 
 ## Overview
 
@@ -57,7 +57,7 @@ Readiness and health (liveness) are different signals, and the difference matter
 * A failing **readiness** check takes the Pod out of the load-balancer rotation but leaves it running. Returning `503` from `/ready` for a while is a normal, deliberate signal — during start-up, or later if a downstream dependency drops out — and the Pod is put back as soon as the check passes again.
 * A failing **health** check restarts the container.
 
-So return not-ready from your readiness path, never from health, when the function is merely warming up or temporarily unable to serve. Otherwise a slow start becomes a restart loop.
+You rarely need a custom health check — the watchdog's built-in liveness is enough — so put the effort into readiness. And return not-ready from your readiness path, never from health, when the function is merely warming up or temporarily unable to serve. Otherwise a slow start becomes a restart loop.
 
 Keep the check on its own path, and keep it cheap. Do not point the probe at `/`: a probe-shaped request can fail what your handler expects, and it would run your real work on every probe — every couple of seconds — for nothing. A good check is a light touch: the init flag above, a quick `db.ping()`, or confirming the model object is loaded.
 

--- a/docs/languages/python/examples/readiness.md
+++ b/docs/languages/python/examples/readiness.md
@@ -2,6 +2,8 @@ Some functions need to do work before they can serve traffic: load a machine-lea
 
 A readiness check lets OpenFaaS hold traffic back until the function signals it is ready. This matters every time a new Pod joins the service — a first deployment, a scale-up to add replicas, a rolling update, a restart, or a scale-from-zero. Without it, the first request to a Pod that is up but still initialising fails with a 500 or a timeout.
 
+The watchdog ships a default readiness check, but it only reports that the watchdog process has started — not that your handler, or the dependencies behind it, can actually serve a request. Closing that gap is the developer's job: expose your own readiness path and have OpenFaaS probe it.
+
 Use-cases:
 
 * Loading an ML model or embeddings at start-up
@@ -47,6 +49,17 @@ def handle(event, context):
 ```
 
 The flag is a plain boolean, which is safe here: the background thread only ever sets it to `True`, and the handler only reads it.
+
+## Readiness is not health
+
+Readiness and health (liveness) are different signals, and the difference matters:
+
+* A failing **readiness** check takes the Pod out of the load-balancer rotation but leaves it running. Returning `503` from `/ready` for a while is a normal, deliberate signal — during start-up, or later if a downstream dependency drops out — and the Pod is put back as soon as the check passes again.
+* A failing **health** check restarts the container.
+
+So return not-ready from your readiness path, never from health, when the function is merely warming up or temporarily unable to serve. Otherwise a slow start becomes a restart loop.
+
+Keep the check on its own path, and keep it cheap. Do not point the probe at `/`: a probe-shaped request can fail what your handler expects, and it would run your real work on every probe — every couple of seconds — for nothing. A good check is a light touch: the init flag above, a quick `db.ping()`, or confirming the model object is loaded.
 
 ## Scaffold the function
 

--- a/docs/languages/python/examples/readiness.md
+++ b/docs/languages/python/examples/readiness.md
@@ -1,0 +1,99 @@
+Some functions need to do work before they can serve traffic: load a machine-learning model, warm a cache, open a database connection pool, or download a dataset. Until that work finishes, the function is running but not yet able to answer requests.
+
+A readiness check lets OpenFaaS hold traffic back until the function signals it is ready. Without one, the first request after a cold start or a scale-from-zero lands on a Pod that is up but still initialising, and fails with a 500 or a timeout.
+
+Use-cases:
+
+* Loading an ML model or embeddings at start-up
+* Warming an in-memory cache
+* Opening a database or SDK connection pool
+* Downloading reference data before the first request
+
+!!! info "OpenFaaS Pro feature"
+    Custom readiness checks are configured with the `com.openfaas.ready.http.*` annotations, which are part of the [OpenFaaS Pro](/openfaas-pro/introduction) distribution. On Community Edition the readiness probe always uses `/_/health` and these annotations are ignored.
+
+## Handler
+
+Run the slow initialisation off the request path — in a background thread started at module load — and set a flag when it finishes. The handler returns `200` from `/ready` once the flag is set, and `503` while it is still initialising.
+
+handler.py:
+
+```python
+import threading
+import time
+
+# Ready is False until the background initialisation has finished.
+ready = False
+
+
+def initialize():
+    global ready
+    # Replace this with the real work: load a model, open a pool, warm a cache.
+    time.sleep(10)
+    ready = True
+
+
+# Start the initialisation once, at module load, not on the request path.
+threading.Thread(target=initialize, daemon=True).start()
+
+
+def handle(event, context):
+    if event.path == "/ready":
+        if ready:
+            return {"statusCode": 200, "body": "Ready"}
+        return {"statusCode": 503, "body": "Initializing"}
+
+    return {"statusCode": 200, "body": "Hello from OpenFaaS"}
+```
+
+The flag is a plain boolean, which is safe here: the background thread only ever sets it to `True`, and the handler only reads it.
+
+## stack.yaml
+
+Point the readiness probe at the `/ready` path with an annotation:
+
+```yaml
+functions:
+  ready-example:
+    lang: python3-http
+    handler: ./ready-example
+    image: ${REGISTRY}/ready-example:latest
+    annotations:
+      com.openfaas.ready.http.path: /ready
+      com.openfaas.ready.http.initialDelaySeconds: 2
+      com.openfaas.ready.http.periodSeconds: 2
+```
+
+For a slow initialisation, raise `initialDelaySeconds` so the first probe fires after the work is expected to have finished, rather than probing on a tight loop while the model is still loading:
+
+```yaml
+    annotations:
+      com.openfaas.ready.http.path: /ready
+      com.openfaas.ready.http.initialDelaySeconds: 60   # wait 60s before the first probe
+      com.openfaas.ready.http.periodSeconds: 5
+```
+
+The full set of probe annotations (`timeoutSeconds`, `successThreshold`, `failureThreshold`) is listed under [Workloads](/reference/workloads/#custom-http-health-checks).
+
+## Deploy and verify
+
+```bash
+faas-cli up
+```
+
+Confirm the function reports `Ready` before treating it as available:
+
+```bash
+faas-cli describe ready-example
+```
+
+To see the check working, scale to zero and invoke it — the first request must succeed rather than return a 500:
+
+```bash
+curl https://$OPENFAAS_URL/function/ready-example
+```
+
+## See also
+
+* [Workloads: custom HTTP health checks](/reference/workloads/)
+* [Health and readiness for functions](https://www.openfaas.com/blog/health-and-readiness-for-functions/)

--- a/docs/languages/python/examples/readiness.md
+++ b/docs/languages/python/examples/readiness.md
@@ -1,6 +1,6 @@
 Some functions need to do work before they can serve traffic: load a machine-learning model, warm a cache, open a database connection pool, or download a dataset. Until that work finishes, the function is running but not yet able to answer requests.
 
-A readiness check lets OpenFaaS hold traffic back until the function signals it is ready. Without one, the first request after a cold start or a scale-from-zero lands on a Pod that is up but still initialising, and fails with a 500 or a timeout.
+A readiness check lets OpenFaaS hold traffic back until the function signals it is ready. This matters every time a new Pod joins the service — a first deployment, a scale-up to add replicas, a rolling update, a restart, or a scale-from-zero. Without it, the first request to a Pod that is up but still initialising fails with a 500 or a timeout.
 
 Use-cases:
 
@@ -100,11 +100,17 @@ The function reports `Not Ready` until `initialize()` finishes, then `Ready`. Co
 faas-cli describe ready-example
 ```
 
-Because the readiness probe holds traffic back until then, the first request to any freshly started Pod — after a cold start, a rolling update, or a scale-from-zero — succeeds rather than returning a 500:
+Because the readiness probe holds traffic back until then, the first request to any freshly started Pod — whether from a first deployment, a scale-up, a rolling update, a restart, or a scale-from-zero — succeeds rather than returning a 500:
 
 ```bash
 curl https://$OPENFAAS_URL/function/ready-example
 ```
+
+## The other half: draining on the way down
+
+Readiness governs a Pod joining the load balancer on the way up. Coming back down — a scale-down, a rolling update replacing the Pod, or a scale-to-zero — is a separate concern: the Pod should finish any in-flight requests before it is removed, rather than dropping them.
+
+That is handled by the watchdog's graceful shutdown, not by the readiness check. On OpenFaaS Pro, the `write_timeout` environment variable sets how long Kubernetes waits for in-flight work to drain before removing the Pod. See [Custom TerminationGracePeriod](/reference/workloads/#custom-terminationgraceperiod-for-long-running-functions).
 
 ## See also
 

--- a/docs/languages/python/index.md
+++ b/docs/languages/python/index.md
@@ -493,3 +493,4 @@ def handle(event, context):
 * [OpenTelemetry zero-code instrumentation](examples/opentelemetry.md)
 * [Use AWS IAM Roles for Service Accounts (IRSA)](examples/ecr-irsa.md)
 * [Stream Server-Sent Events (SSE)](examples/sse.md)
+* [Readiness checks for slow start-up](examples/readiness.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
             - OpenTelemetry zero-code instrumentation: ./languages/python/examples/opentelemetry.md
             - AWS IAM Roles (IRSA): ./languages/python/examples/ecr-irsa.md
             - Stream Server-Sent Events (SSE): ./languages/python/examples/sse.md
+            - Readiness checks for slow start-up: ./languages/python/examples/readiness.md
     - Node: ./languages/node.md
     - Go: ./languages/go.md
     - C#: ./languages/csharp.md


### PR DESCRIPTION
Adds a focused Python example for the "wait until start-up work is done" pattern — loading an ML model, warming a cache, opening a connection pool — which the Python docs didn't cover as an example (only a passing mention in the index).

The example:

- runs the slow work in a background thread at module load, off the request path
- returns `503` from `/ready` until it finishes, then `200`
- points the readiness probe at that path via `com.openfaas.ready.http.path`
- covers raising `initialDelaySeconds` for slow model loads

It is clearly labelled as an **OpenFaaS Pro feature**, consistent with [Workloads](/reference/workloads/#custom-http-health-checks): on Community Edition the readiness probe always uses `/_/health` and the `com.openfaas.ready.http.*` annotations are ignored.

New page `languages/python/examples/readiness.md`, added to the nav in `mkdocs.yml` and the Examples list in the Python index. The `503 -> 200` handler logic and the `#custom-http-health-checks` anchor were both verified.
