### PR TITLE
Document inferred SSO provider defaults

### DIFF
--- a/docs/openfaas-pro/sso/google.md
+++ b/docs/openfaas-pro/sso/google.md
@@ -52,11 +52,10 @@ This guide will cover how to configure Google as an identity provider for OpenFa
 !!! note "SSO with the faas-cli"
 
     Google does not support the Authorization Code flow with Proof Key of Code Exchange (PKCE).
-    To login with the faas-cli use the Implicit Id flow. 
+    When the faas-cli detects a Google client ID, it automatically uses the Implicit Id flow and the authority `https://accounts.google.com`.
+    These defaults can be overridden with the `--grant` and `--authority` flags.
 
     ```sh
     faas-cli pro auth \
-      --grant implicit-id \
-      --authority https://accounts.google.com \
-      --client-id CLIENT_ID
+      --client-id CLIENT_ID.apps.googleusercontent.com
     ```

--- a/docs/openfaas-pro/sso/microsoft-entra.md
+++ b/docs/openfaas-pro/sso/microsoft-entra.md
@@ -68,7 +68,8 @@ This guide covers how to configure [Microsoft Entra]() as an identity provider f
 
 !!! Note "SSO with the faas-cli"
 
-    By default the faas-cli pro auth listens for OAuth callbacks on the address `http://127.0.0.1`. Entra does not support using the loopback address for redirect URIs. You need to explicitly set the flag `--redirect-host=http://localhost` to override the default value.
+    The faas-cli defaults to `--redirect-host=http://localhost` when a Microsoft Entra authority is configured because Entra does not support using a loopback IP address for redirect URIs.
+    The callback address can be overridden with the `--redirect-host` flag.
     
     To login with the faas-cli when using Azure Entra as the identity provider we recommend using the Implicit Id flow.
 
@@ -76,6 +77,5 @@ This guide covers how to configure [Microsoft Entra]() as an identity provider f
     faas-cli pro auth \
       --grant=implicit-id \
       --authority=https://login.microsoftonline.com/1fe3798478-5987-2564-b4aa-99e587365024/v2.0 \
-      --client-id=068cb5cb-8cc3-4d57-8263-d6c6ce52ddff \
-      --redirect-host=http://localhost
+      --client-id=068cb5cb-8cc3-4d57-8263-d6c6ce52ddff
     ```


### PR DESCRIPTION
## Description

Update the Google and Microsoft Entra SSO pages to reflect provider-specific defaults inferred by the faas-cli.

The Google page documents the automatically selected authority and Implicit Id grant, along with the flags available to override those values. The example now only requires a Google client ID.

The Microsoft Entra page documents the automatic `http://localhost` callback address and the `--redirect-host` override. The example no longer includes the inferred redirect-host flag.

## Motivation and Context

The faas-cli now infers common authentication values for Google and Microsoft Entra. The provider guides should show the simplified command-line experience while continuing to document the available flags and their default values.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Reviewed the updated Markdown and verified the examples match the new faas-cli pro behavior.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`