### PR TITLE
Document OPENFAAS_NS default namespace override

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -111,6 +111,7 @@ Several overrides exist which will be used by default if set and no other comman
 * `OPENFAAS_TEMPLATE_URL` - to set the default URL to pull templates from
 * `OPENFAAS_PREFIX` - for use with `faas-cli new` - this can act in place of `--prefix`
 * `OPENFAAS_URL` - to override the default gateway URL
+* `OPENFAAS_NS` - to set the default function namespace
 
 ## Running `faas-cli` with sudo
 

--- a/docs/reference/namespaces.md
+++ b/docs/reference/namespaces.md
@@ -108,6 +108,21 @@ faas-cli deploy --namespace staging-fn
 openssl rand -base64 32 | faas-cli invoke --namespace staging-fn stronghash
 ```
 
+## Set a default namespace with `OPENFAAS_NS`
+
+You can set a default function namespace for the `faas-cli` with the `OPENFAAS_NS` environment variable. This is useful when you have access to a non-default namespace and do not want to pass the `--namespace` flag on every command.
+
+```sh
+export OPENFAAS_NS=staging-fn
+```
+
+The namespace is resolved with the following precedence (highest first):
+
+1. The `--namespace` flag
+2. The `namespace` field in the `stack.yml`
+3. The `OPENFAAS_NS` environment variable
+4. The default namespace (`openfaas-fn`)
+
 ## Controlling network access
 
 You should consider whether network policies or service mesh policies are required to restrict traffic between namespaces.


### PR DESCRIPTION
## Description

Add `OPENFAAS_NS` to the faas-cli environment variable overrides list and document it in the namespaces reference.

## Motivation and Context

The faas-cli now supports `OPENFAAS_NS` as a default function namespace, resolved after the `--namespace` flag and the `stack.yml` namespace field. Document the variable and its precedence.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Reviewed the updated Markdown.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
